### PR TITLE
fix:修复编辑过滤组件时，悬浮组件依然在遮罩上方

### DIFF
--- a/frontend/src/views/Tinymce/FilterTextAttr.vue
+++ b/frontend/src/views/Tinymce/FilterTextAttr.vue
@@ -150,7 +150,7 @@ export default {
   }
   .el-card-main {
     height: 34px;
-    z-index: 1000000000;
+    z-index: 10;
     width: 350px;
     position: absolute;
 

--- a/frontend/src/views/Tinymce/RectangleAttr.vue
+++ b/frontend/src/views/Tinymce/RectangleAttr.vue
@@ -172,7 +172,7 @@ export default {
   }
   .el-card-main {
     height: 34px;
-    z-index: 1000000000;
+    z-index: 10;
     width: 210px;
     position: absolute;
 

--- a/frontend/src/views/Tinymce/TextAttr.vue
+++ b/frontend/src/views/Tinymce/TextAttr.vue
@@ -165,7 +165,7 @@ export default {
   }
   .el-card-main {
     height: 34px;
-    z-index: 1000000000;
+    z-index: 10;
     width: 450px;
     position: absolute;
 


### PR DESCRIPTION
fix:修复编辑过滤组件时，悬浮组件依然在遮罩上方 