### PR TITLE
refactor:编辑时视图的设置按钮永远在最上层

### DIFF
--- a/frontend/src/components/DeDrag/index.vue
+++ b/frontend/src/components/DeDrag/index.vue
@@ -20,7 +20,7 @@
     @mouseenter="enter"
     @mouseleave="leave"
   >
-    <edit-bar v-if="active||linkageSettingStatus" :active-model="'edit'" :element="element" @showViewDetails="showViewDetails" />
+    <edit-bar style="transform: translateZ(10px)" v-if="active||linkageSettingStatus" :active-model="'edit'" :element="element" @showViewDetails="showViewDetails" />
     <div
       v-for="(handlei, indexi) in actualHandles"
       :key="indexi"
@@ -1566,6 +1566,7 @@ export default {
 .vdr {
   touch-action: none;
   position: absolute;
+  transform-style:preserve-3d;
   border: 1px
 }
 

--- a/frontend/src/components/canvas/components/Editor/index.vue
+++ b/frontend/src/components/canvas/components/Editor/index.vue
@@ -637,6 +637,7 @@ export default {
     /*background: #fff;*/
     margin: auto;
     background-size:100% 100% !important;
+    transform-style:preserve-3d;
 
     .lock {
         opacity: .5;


### PR DESCRIPTION
refactor:编辑时视图的设置按钮永远在最上层 