### PR TITLE
fix: 画布出现滚动条时，拖入的组件会靠上的问题

### DIFF
--- a/frontend/src/components/canvas/components/Editor/index.vue
+++ b/frontend/src/components/canvas/components/Editor/index.vue
@@ -813,6 +813,10 @@ export default {
           y: 18
         }
       }
+    },
+    scrollTop: {
+      type: Number,
+      default: 0
     }
   },
   data() {
@@ -1251,9 +1255,8 @@ export default {
       }
     },
     handleDragOver(e) {
-      // console.log('handleDragOver-Editor')
       this.dragComponentInfo.shadowStyle.x = e.pageX - 220
-      this.dragComponentInfo.shadowStyle.y = e.pageY - 90
+      this.dragComponentInfo.shadowStyle.y = e.pageY - 90 + this.scrollTop
       this.dragComponentInfo.style.left = this.dragComponentInfo.shadowStyle.x / this.scalePointWidth
       this.dragComponentInfo.style.top = this.dragComponentInfo.shadowStyle.y / this.scalePointHeight
       if (this.dragComponentInfo.auxiliaryMatrix) {

--- a/frontend/src/views/panel/edit/index.vue
+++ b/frontend/src/views/panel/edit/index.vue
@@ -106,7 +106,7 @@
           @mouseup="deselectCurComponent"
           @scroll="canvasScroll"
         >
-          <Editor ref="canvasEditor" :matrix-count="pcMatrixCount" :out-style="outStyle" />
+          <Editor ref="canvasEditor" :matrix-count="pcMatrixCount" :out-style="outStyle" :scroll-top="scrollTop" />
         </div>
         <!--移动端画布区域 保持宽高比2.5-->
         <el-row v-if="mobileLayoutStatus" class="mobile_canvas_main">
@@ -126,7 +126,7 @@
                 id="canvasInfoMobile"
                 class="this_mobile_canvas_main"
               >
-                <Editor ref="editorMobile" :matrix-count="mobileMatrixCount" :out-style="outStyle" />
+                <Editor ref="editorMobile" :matrix-count="mobileMatrixCount" :out-style="outStyle" :scroll-top="scrollTop" />
               </el-row>
               <el-row class="this_mobile_canvas_bottom" />
             </div>


### PR DESCRIPTION
fix: 画布出现滚动条时，拖入的组件会靠上的问题 