### PR TITLE
fix: 仪表板编辑移入过滤组件时，点击叉号关闭出现占位未取消的问题

### DIFF
--- a/frontend/src/views/panel/edit/index.vue
+++ b/frontend/src/views/panel/edit/index.vue
@@ -144,6 +144,7 @@
       :title="(currentWidget && currentWidget.getLeftPanel && currentWidget.getLeftPanel().label ? $t(currentWidget.getLeftPanel().label) : '') + $t('panel.module')"
       :visible.sync="filterVisible"
       custom-class="de-filter-dialog"
+      @close="cancelFilter"
     >
       <filter-dialog v-if="filterVisible && currentWidget" :widget-info="currentWidget" :component-info="currentFilterCom" @re-fresh-component="reFreshComponent">
         <component


### PR DESCRIPTION
fix: 仪表板编辑移入过滤组件时，点击叉号关闭出现占位未取消的问题 