### PR TITLE
fixed: oracle同步字段时同步注释（Mysql没这个问题）

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -102,6 +102,12 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>12.2.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.pagehelper</groupId>
             <artifactId>pagehelper</artifactId>
             <version>5.0.3</version>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -102,12 +102,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.database.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>12.2.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.pagehelper</groupId>
             <artifactId>pagehelper</artifactId>
             <version>5.0.3</version>

--- a/backend/src/main/java/io/dataease/provider/datasource/JdbcProvider.java
+++ b/backend/src/main/java/io/dataease/provider/datasource/JdbcProvider.java
@@ -2,6 +2,7 @@ package io.dataease.provider.datasource;
 
 import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.pool.DruidDataSource;
+import com.alibaba.druid.pool.DruidPooledConnection;
 import com.alibaba.druid.wall.WallFilter;
 import com.google.gson.Gson;
 import io.dataease.commons.constants.DatasourceTypes;
@@ -18,6 +19,7 @@ import javax.annotation.PostConstruct;
 import java.beans.PropertyVetoException;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.sql.*;
 import java.util.*;
@@ -143,6 +145,10 @@ public class JdbcProvider extends DatasourceProvider {
         }
         List<TableFiled> list = new LinkedList<>();
         try (Connection connection = getConnectionFromPool(datasourceRequest)) {
+            if (datasourceRequest.getDatasource().getType().equalsIgnoreCase("oracle")) {
+                Method setRemarksReporting = extendedJdbcClassLoader.loadClass("oracle.jdbc.driver.OracleConnection").getMethod("setRemarksReporting",boolean.class);
+                setRemarksReporting.invoke(((DruidPooledConnection) connection).getConnection(), true);
+            }
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             ResultSet resultSet = databaseMetaData.getColumns(null, "%", datasourceRequest.getTable(), "%");
             while (resultSet.next()) {


### PR DESCRIPTION
修复数据库类型为Oracle时，添加数据库数据集表字段不会同步注释的问题。