### PR TITLE
fix: 重新开启链接后，老的链接无效

### DIFF
--- a/backend/src/main/java/io/dataease/service/panel/PanelLinkService.java
+++ b/backend/src/main/java/io/dataease/service/panel/PanelLinkService.java
@@ -238,7 +238,9 @@ public class PanelLinkService {
         example.createCriteria().andUuidEqualTo(uuid);
         List<PanelLinkMapping> mappings = panelLinkMappingMapper.selectByExample(example);
         if (CollectionUtils.isEmpty(mappings)) {
-            DEException.throwException("link is not exist");
+            PanelLink panelLink = new PanelLink();
+            panelLink.setResourceId("error-resource-id");
+            return BASEURL + buildLinkParam(panelLink);
         }
         PanelLinkMapping mapping = mappings.get(0);
         String resourceId = mapping.getResourceId();


### PR DESCRIPTION
fix: 重新开启链接后，老的链接无效 