### PR TITLE
fix: 公共链接不能显示气泡地图

### DIFF
--- a/backend/src/main/java/io/dataease/service/chart/ChartViewService.java
+++ b/backend/src/main/java/io/dataease/service/chart/ChartViewService.java
@@ -803,7 +803,7 @@ public class ChartViewService {
         pluginViewParam.setPluginChartFieldCustomFilters(fieldFilters);
         pluginViewParam.setPluginChartExtFilters(panelFilters);
         pluginViewParam.setPluginViewLimit(pluginViewLimit);
-        pluginViewParam.setUserId(AuthUtils.getUser().getUserId());
+        // pluginViewParam.setUserId(AuthUtils.getUser().getUserId());
         return pluginViewParam;
     }
 


### PR DESCRIPTION
fix: 公共链接不能显示气泡地图 