### PR TITLE
fix: 视图切换数据集维度关闭后没有立即生效

### DIFF
--- a/frontend/src/views/chart/view/ChartEdit.vue
+++ b/frontend/src/views/chart/view/ChartEdit.vue
@@ -2300,7 +2300,7 @@ export default {
 
     closeEditDsField() {
       this.editDsField = false
-      this.initTableField()
+      this.initTableField(this.tabel.id)
     },
 
     // drag


### PR DESCRIPTION
fix: 视图切换数据集维度关闭后没有立即生效 