### PR TITLE
fix: 解决编辑仪表板时视图过多导致的死锁异常问题

### DIFF
--- a/backend/src/main/java/io/dataease/service/chart/ChartViewCacheService.java
+++ b/backend/src/main/java/io/dataease/service/chart/ChartViewCacheService.java
@@ -18,7 +18,7 @@ public class ChartViewCacheService {
     @Resource
     private ExtChartViewMapper extChartViewMapper;
 
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void refreshCache(String viewId){
         if(extChartViewMapper.updateToCache(viewId)==0){
             extChartViewMapper.copyToCache(viewId);


### PR DESCRIPTION
现象：编辑仪表板时视图报死锁异常
解决：mysql的默认事务级别为REPEATABLE_READ，调整为READ_COMMITTED后不报死锁异常，或者直接去掉
具体日志如下：
### Error updating database.  Cause: com.mysql.cj.jdbc.exceptions.MySQLTransactionRollbackException: Deadlock found when trying to get lock; try restarting transaction
### The error may exist in io/dataease/base/mapper/ext/ExtChartViewMapper.xml
### The error may involve defaultParameterMap
### The error occurred while setting parameters
### SQL: INSERT INTO chart_view_cache (             id,             `name`,             title,             scene_id,             table_id,             `type`,             render,             result_count,             result_mode,             create_by,             create_time,             update_time,             style_priority,             chart_type,             is_plugin,             x_axis,             x_axis_ext,             y_axis,             y_axis_ext,             ext_stack,             ext_bubble,             custom_attr,             custom_style,             custom_filter,             drill_fields,             senior,             SNAPSHOT,             data_from             ) SELECT             id,             `name`,             title,             scene_id,             table_id,             `type`,             render,             result_count,             result_mode,             create_by,             create_time,             update_time,             style_priority,             chart_type,             is_plugin,             x_axis,             x_axis_ext,             y_axis,             y_axis_ext,             ext_stack,             ext_bubble,             custom_attr,             custom_style,             custom_filter,             drill_fields,             senior,             SNAPSHOT,             data_from  from chart_view         WHERE             chart_view.id   = ?
