### PR TITLE
fix: 移动端访问https升级策略放在nginx而不是页面代码中

### DIFF
--- a/mobile/public/index.html
+++ b/mobile/public/index.html
@@ -3,7 +3,6 @@
 
     <head>
         <meta charset="utf-8">
-		<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <title>
             <%= htmlWebpackPlugin.options.title %>


### PR DESCRIPTION
fix: 移动端访问https升级策略放在nginx而不是页面代码中 