### PR TITLE
feat: 新增用户修改个人信息功能

### DIFF
--- a/backend/src/main/java/io/dataease/controller/sys/SysUserController.java
+++ b/backend/src/main/java/io/dataease/controller/sys/SysUserController.java
@@ -119,7 +119,22 @@ public class SysUserController {
     @ApiOperation("更新个人信息")
     @PostMapping("/updatePersonInfo")
     public void updatePersonInfo(@RequestBody SysUserCreateRequest request) {
-        sysUserService.updatePersonInfo(request);
+        Long userId = AuthUtils.getUser().getUserId();
+        // 防止修改他人信息， 防止必填内容留空
+        if (!request.getUserId().equals(userId) || request.getEmail() == null || request.getNickName() == null) {
+            throw new RuntimeException("内容不合法");
+        }
+        // 再次验证，匹配格式
+        if (!request.getPhone().isEmpty() && !request.getPhone().matches("^1[3|4|5|7|8][0-9]{9}$")) {
+            throw new RuntimeException("电话格式错误");
+        }
+        if (!request.getEmail().matches("^[a-zA-Z0-9_._-]+@[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9_-]+)+$")) {
+            throw new RuntimeException("邮箱格式错误");
+        }
+        if (!(2 <= request.getNickName().length() && request.getNickName().length() <= 50)) {
+            throw new RuntimeException("姓名格式错误");
+        }
+        sysUserService.updatePersonBasicInfo(request);
     }
 
     @ApiOperation("设置语言")

--- a/frontend/src/api/system/user.js
+++ b/frontend/src/api/system/user.js
@@ -68,7 +68,7 @@ export const editStatus = (data) => {
   })
 }
 
-export const persionInfo = () => {
+export const personInfo = () => {
   return request({
     url: pathMap.personInfoPath,
     method: 'post'
@@ -133,4 +133,4 @@ export function existLdapUsers() {
   })
 }
 
-export default { editPassword, delUser, editUser, addUser, userLists, editStatus, persionInfo, updatePerson, updatePersonPwd, allRoles, roleGrid, ldapUsers, saveLdapUser, existLdapUsers }
+export default { editPassword, delUser, editUser, addUser, userLists, editStatus, personInfo, updatePerson, updatePersonPwd, allRoles, roleGrid, ldapUsers, saveLdapUser, existLdapUsers }

--- a/frontend/src/views/system/user/privateForm.vue
+++ b/frontend/src/views/system/user/privateForm.vue
@@ -5,18 +5,18 @@
         <div class="form-header">
           <span>{{ $t('commons.personal_info') }}</span>
         </div>
-        <el-form ref="createUserForm" :disabled="formType !== 'modify'" :model="form" :rules="rule" size="small" label-width="auto" label-position="right">
+        <el-form ref="createUserForm" :model="form" :rules="rule" size="small" label-width="auto" label-position="right">
           <el-form-item label="ID" prop="username">
             <el-input v-model="form.username" disabled />
           </el-form-item>
           <el-form-item :label="$t('commons.phone')" prop="phone">
-            <el-input v-model="form.phone" />
+            <el-input v-model="form.phone" :disabled="formType!=='modify'" />
           </el-form-item>
           <el-form-item :label="$t('commons.nick_name')" prop="nickName">
-            <el-input v-model="form.nickName" />
+            <el-input v-model="form.nickName" :disabled="formType!=='modify'" />
           </el-form-item>
           <el-form-item :label="$t('commons.email')" prop="email">
-            <el-input v-model="form.email" />
+            <el-input v-model="form.email" :disabled="formType!=='modify'" />
           </el-form-item>
 
           <el-form-item :label="$t('commons.status')">
@@ -33,9 +33,9 @@
               :load-options="loadDepts"
               :auto-load-root-options="false"
               :placeholder="$t('user.choose_org')"
-              :noChildrenText="$t('commons.treeselect.no_children_text')"
-              :noOptionsText="$t('commons.treeselect.no_options_text')"
-              :noResultsText="$t('commons.treeselect.no_results_text')"
+              :no-children-text="$t('commons.treeselect.no_children_text')"
+              :no-options-text="$t('commons.treeselect.no_options_text')"
+              :no-results-text="$t('commons.treeselect.no_results_text')"
             />
           </el-form-item>
           <el-form-item :label="$t('commons.role')" prop="roleIds">
@@ -56,10 +56,14 @@
               />
             </el-select>
           </el-form-item>
-          <!-- <el-form-item>
-        <el-button v-if="formType==='modify'" type="primary" @click="save">保存</el-button>
-        <el-button v-if="formType==='modify'" @click="reset">重置</el-button>
-      </el-form-item> -->
+          <!--提供修改个人电话，邮箱和昵称的功能-->
+          <el-form-item v-if="formType!=='modify'">
+            <el-button @click="formType = 'modify'">修改个人信息</el-button>
+          </el-form-item>
+          <el-form-item v-else>
+            <el-button v-if="formType==='modify'" type="primary" @click="save">保存</el-button>
+            <el-button v-if="formType==='modify'" @click="reset">取消</el-button>
+          </el-form-item>
         </el-form>
 
         <div slot="footer" style="margin-left: 30px;" class="dialog-footer">
@@ -81,7 +85,7 @@ import { PHONE_REGEX } from '@/utils/validate'
 import { LOAD_CHILDREN_OPTIONS, LOAD_ROOT_OPTIONS } from '@riophae/vue-treeselect'
 import { getDeptTree, treeByDeptId } from '@/api/system/dept'
 import { allRoles } from '@/api/system/user'
-import { updatePerson, persionInfo } from '@/api/system/user'
+import { updatePerson, personInfo } from '@/api/system/user'
 export default {
 
   components: { LayoutContent, Treeselect },
@@ -170,7 +174,7 @@ export default {
   methods: {
 
     queryPerson() {
-      persionInfo().then(res => {
+      personInfo().then(res => {
         const info = res.data
         this.form = info
         const roles = info.roles
@@ -255,6 +259,8 @@ export default {
     reset() {
       this.formType = 'add'
       this.queryPerson()
+      // 清空表单提示
+      this.$refs.createUserForm.clearValidate()
     },
     save() {
       this.$refs.createUserForm.validate(valid => {


### PR DESCRIPTION
#### What this PR does / why we need it?
修复[issue 1298](https://github.com/dataease/dataease/issues/1298) :"个人信息建议可以修改某些字段"
#### Summary of your change
增加了用户修改个人信息的功能。电话，姓名，邮箱信息可在个人页面修改。
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
