### PR TITLE
fix: 批量设置视图样式时，若样式菜单过长，则无法滚动选择到底部的样式选项

### DIFF
--- a/frontend/src/views/chart/view/ChartStyleBatchSet.vue
+++ b/frontend/src/views/chart/view/ChartStyleBatchSet.vue
@@ -5,6 +5,7 @@
     </el-row>
     <chart-style
       v-if="mixProperties&&batchOptChartInfo"
+      class="chart-style-main"
       :param="param"
       :view="batchOptChartInfo"
       :chart="batchOptChartInfo"
@@ -128,6 +129,10 @@ export default {
     overflow-y: hidden;
     width: 100%;
     border-left: 1px solid #E6E6E6
+  }
+
+  .chart-style-main{
+    height:  calc(100% - 40px)!important;
   }
 
   .view-title-name {


### PR DESCRIPTION
fix: 批量设置视图样式时，若样式菜单过长，则无法滚动选择到底部的样式选项 