### PR TITLE
feat:提高请求超时时间的范围，创建关联数据集时保留原数据类型

### DIFF
--- a/backend/src/main/java/io/dataease/controller/sys/SystemParameterController.java
+++ b/backend/src/main/java/io/dataease/controller/sys/SystemParameterController.java
@@ -70,7 +70,7 @@ public class SystemParameterController {
         int timeout = Integer.parseInt(systemParameter.stream().filter(
                 parameter -> parameter.getParamKey().equals("basic.frontTimeOut")
         ).findFirst().get().getParamValue());
-        if (timeout < 0 || timeout > 300) {
+        if (timeout < 0 || timeout > 300) { //增加了合法性检验
             throw new NumberFormatException("Timeout Range Error!");
         }
         systemParameterService.editBasic(systemParameter);

--- a/backend/src/main/java/io/dataease/controller/sys/SystemParameterController.java
+++ b/backend/src/main/java/io/dataease/controller/sys/SystemParameterController.java
@@ -67,6 +67,12 @@ public class SystemParameterController {
     @RequiresPermissions("sysparam:read")
     @PostMapping("/edit/basic")
     public void editBasic(@RequestBody List<SystemParameter> systemParameter) {
+        int timeout = Integer.parseInt(systemParameter.stream().filter(
+                parameter -> parameter.getParamKey().equals("basic.frontTimeOut")
+        ).findFirst().get().getParamValue());
+        if (timeout < 0 || timeout > 300) {
+            throw new NumberFormatException("Timeout Range Error!");
+        }
         systemParameterService.editBasic(systemParameter);
     }
 

--- a/backend/src/main/java/io/dataease/provider/engine/mysql/MysqlQueryProvider.java
+++ b/backend/src/main/java/io/dataease/provider/engine/mysql/MysqlQueryProvider.java
@@ -62,7 +62,7 @@ public class MysqlQueryProvider extends QueryProvider {
             case "MEDIUMINT":
             case "INTEGER":
             case "BIGINT":
-            case "LONG":
+            case "LONG": //增加了LONG类型
                 return 2;// 整型
             case "FLOAT":
             case "DOUBLE":

--- a/backend/src/main/java/io/dataease/provider/engine/mysql/MysqlQueryProvider.java
+++ b/backend/src/main/java/io/dataease/provider/engine/mysql/MysqlQueryProvider.java
@@ -62,6 +62,7 @@ public class MysqlQueryProvider extends QueryProvider {
             case "MEDIUMINT":
             case "INTEGER":
             case "BIGINT":
+            case "LONG":
                 return 2;// 整型
             case "FLOAT":
             case "DOUBLE":

--- a/backend/src/main/java/io/dataease/provider/query/mysql/MysqlQueryProvider.java
+++ b/backend/src/main/java/io/dataease/provider/query/mysql/MysqlQueryProvider.java
@@ -63,6 +63,7 @@ public class MysqlQueryProvider extends QueryProvider {
             case "MEDIUMINT":
             case "INTEGER":
             case "BIGINT":
+            case "LONG":
                 return 2;// 整型
             case "FLOAT":
             case "DOUBLE":

--- a/backend/src/main/java/io/dataease/provider/query/mysql/MysqlQueryProvider.java
+++ b/backend/src/main/java/io/dataease/provider/query/mysql/MysqlQueryProvider.java
@@ -63,7 +63,7 @@ public class MysqlQueryProvider extends QueryProvider {
             case "MEDIUMINT":
             case "INTEGER":
             case "BIGINT":
-            case "LONG":
+            case "LONG": //增加了LONG类型
                 return 2;// 整型
             case "FLOAT":
             case "DOUBLE":

--- a/backend/src/main/java/io/dataease/service/dataset/DataSetTableService.java
+++ b/backend/src/main/java/io/dataease/service/dataset/DataSetTableService.java
@@ -1614,7 +1614,7 @@ public class DataSetTableService {
                                 TableUtils.fieldName(field.getTableId() + "_" + field.getDataeaseName()),
                                 tableField.getFieldName())) {
                             tableField.setRemarks(field.getName());
-                            tableField.setFieldType(field.getType());
+                            tableField.setFieldType(field.getType()); //将原有的type赋值给新创建的数据列
                             break;
                         }
                     }

--- a/backend/src/main/java/io/dataease/service/dataset/DataSetTableService.java
+++ b/backend/src/main/java/io/dataease/service/dataset/DataSetTableService.java
@@ -1614,6 +1614,7 @@ public class DataSetTableService {
                                 TableUtils.fieldName(field.getTableId() + "_" + field.getDataeaseName()),
                                 tableField.getFieldName())) {
                             tableField.setRemarks(field.getName());
+                            tableField.setFieldType(field.getType());
                             break;
                         }
                     }

--- a/frontend/src/lang/en.js
+++ b/frontend/src/lang/en.js
@@ -640,7 +640,7 @@ export default {
     login_type: 'Default login type',
     empty_front: 'If empty then default value is 10s',
     empty_msg: 'If empty then default value is 30 days',
-    front_error: 'Valid ranger [0 - 300]',
+    front_error: 'Valid ranger [0 - 300]', //修改了提示信息
     msg_error: 'Valid ranger [1 - 365]',
     SMTP_port: 'SMTP Port',
     SMTP_account: 'SMTP Account',

--- a/frontend/src/lang/en.js
+++ b/frontend/src/lang/en.js
@@ -640,7 +640,7 @@ export default {
     login_type: 'Default login type',
     empty_front: 'If empty then default value is 10s',
     empty_msg: 'If empty then default value is 30 days',
-    front_error: 'Valid ranger [0 - 100]',
+    front_error: 'Valid ranger [0 - 300]',
     msg_error: 'Valid ranger [1 - 365]',
     SMTP_port: 'SMTP Port',
     SMTP_account: 'SMTP Account',

--- a/frontend/src/lang/tw.js
+++ b/frontend/src/lang/tw.js
@@ -642,7 +642,7 @@ export default {
     login_type: '默認登錄方式',
     empty_front: '為空則默認取值10秒',
     empty_msg: '為空則默認取值30天',
-    front_error: '請填寫0-100正整數',
+    front_error: '請填寫0-300正整數',
     msg_error: '請填寫1-365正整數',
     SMTP_port: 'SMTP端口',
     SMTP_account: 'SMTP賬戶',

--- a/frontend/src/lang/tw.js
+++ b/frontend/src/lang/tw.js
@@ -642,7 +642,7 @@ export default {
     login_type: '默認登錄方式',
     empty_front: '為空則默認取值10秒',
     empty_msg: '為空則默認取值30天',
-    front_error: '請填寫0-300正整數',
+    front_error: '請填寫0-300正整數', //修改了提示信息
     msg_error: '請填寫1-365正整數',
     SMTP_port: 'SMTP端口',
     SMTP_account: 'SMTP賬戶',

--- a/frontend/src/lang/zh.js
+++ b/frontend/src/lang/zh.js
@@ -643,7 +643,7 @@ export default {
     login_type: '默认登录方式',
     empty_front: '为空则默认取10秒',
     empty_msg: '为空则默认取30天',
-    front_error: '请填写0-100正整数',
+    front_error: '请填写0-300正整数',
     msg_error: '请填写1-365正整数',
     SMTP_port: 'SMTP端口',
     SMTP_account: 'SMTP账户',

--- a/frontend/src/lang/zh.js
+++ b/frontend/src/lang/zh.js
@@ -643,7 +643,7 @@ export default {
     login_type: '默认登录方式',
     empty_front: '为空则默认取10秒',
     empty_msg: '为空则默认取30天',
-    front_error: '请填写0-300正整数',
+    front_error: '请填写0-300正整数', //修改了提示信息
     msg_error: '请填写1-365正整数',
     SMTP_port: 'SMTP端口',
     SMTP_account: 'SMTP账户',

--- a/frontend/src/views/system/SysParam/BasicSetting.vue
+++ b/frontend/src/views/system/SysParam/BasicSetting.vue
@@ -86,7 +86,7 @@ export default {
       rules: {
         frontTimeOut: [
           {
-            pattern: '^([0-9]|\\b[1-9]\\d\\b|\\b[1-2]\\d\\d\\b|\\b300\\b)$',
+            pattern: '^([0-9]|\\b[1-9]\\d\\b|\\b[1-2]\\d\\d\\b|\\b300\\b)$', //修改了正则表达式，让其正确匹配0-300的数值
             message: this.$t('system_parameter_setting.front_error'),
             trigger: 'blur'
           }

--- a/frontend/src/views/system/SysParam/BasicSetting.vue
+++ b/frontend/src/views/system/SysParam/BasicSetting.vue
@@ -86,7 +86,7 @@ export default {
       rules: {
         frontTimeOut: [
           {
-            pattern: '^([0-9]{1,2}|100)$',
+            pattern: '^([0-9]|\\b[1-9]\\d\\b|\\b[1-2]\\d\\d\\b|\\b300\\b)$',
             message: this.$t('system_parameter_setting.front_error'),
             trigger: 'blur'
           }


### PR DESCRIPTION
#### What this PR does / why we need it?
修复[issue:2293](https://github.com/dataease/dataease/issues/2293)建议把请求超时时间的设置数值范围加大
修复[issue:2339](https://github.com/dataease/dataease/issues/2339)excel创建关联数据集保留原数据类型
#### Summary of your change
issue:2293
前端将请求超时时间的设置数值范围加大到300，并修改了对应的警告信息
后端增加了合法性验证
issue:2339
后端将原数据列的数据类型赋值给了新生成的数据列，并修改了mysql引擎transFieldType函数对于LONG类型的缺失

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
