### PR TITLE
fix(仪表板): 下拉过滤器删除带有sql注入的排序字段后依然不能点击确认按钮

### DIFF
--- a/frontend/src/components/widget/DeWidget/DeSelect.vue
+++ b/frontend/src/components/widget/DeWidget/DeSelect.vue
@@ -128,6 +128,7 @@ export default {
       this.element.options.attrs.fieldId.length > 0 &&
       method(param).then(res => {
         this.datas = this.optionDatas(res.data)
+        bus.$emit('valid-values-change', true)
       }).catch(e => {
         bus.$emit('valid-values-change', false)
       }) || (this.element.options.value = '')
@@ -169,6 +170,7 @@ export default {
           this.show = true
           this.handleCoustomStyle()
         })
+        bus.$emit('valid-values-change', true)
       }).catch(e => {
         bus.$emit('valid-values-change', false)
       }) || (this.element.options.value = '')
@@ -226,6 +228,7 @@ export default {
         }
         method({ fieldIds: this.element.options.attrs.fieldId.split(','), sort: this.element.options.attrs.sort }).then(res => {
           this.datas = this.optionDatas(res.data)
+          bus.$emit('valid-values-change', true)
         }).catch(e => {
           bus.$emit('valid-values-change', false)
         })


### PR DESCRIPTION
fix(仪表板): 下拉过滤器删除带有sql注入的排序字段后依然不能点击确认按钮 