### PR TITLE
fix: 修复移动端编辑后列表移动端标志没有及时显示

### DIFF
--- a/frontend/src/views/panel/list/PanelList.vue
+++ b/frontend/src/views/panel/list/PanelList.vue
@@ -228,7 +228,7 @@ import LinkGenerate from '@/views/link/generate'
 import { uuid } from 'vue-uuid'
 import bus from '@/utils/bus'
 import EditPanel from './EditPanel'
-import {addGroup, delGroup, groupTree, defaultTree, panelSave, initPanelData, panelUpdate} from '@/api/panel/panel'
+import { addGroup, delGroup, groupTree, defaultTree, panelSave, initPanelData, panelUpdate } from '@/api/panel/panel'
 import { mapState } from 'vuex'
 import {
   DEFAULT_COMMON_CANVAS_STYLE_STRING
@@ -650,6 +650,7 @@ export default {
         this.$store.commit('setComponentDataCache', null)
         initPanelData(data.id, function(response) {
           bus.$emit('set-panel-show-type', 0)
+          data.mobileLayout = response.data.mobileLayout
         })
       }
     },


### PR DESCRIPTION
fix: 修复移动端编辑后列表移动端标志没有及时显示 