### PR TITLE
fix(系统管理): 定时报告发送邮件附件名称过长导致展示错误

### DIFF
--- a/backend/src/main/java/io/dataease/service/system/EmailService.java
+++ b/backend/src/main/java/io/dataease/service/system/EmailService.java
@@ -140,6 +140,7 @@ public class EmailService {
             attach.setFileName(MimeUtility.encodeText(file.getName()));
             multipart.addBodyPart(attach);
         }
+        System.getProperties().setProperty("mail.mime.splitlongparameters", "false");
         multipart.setSubType("related");
         return multipart;
     }


### PR DESCRIPTION
fix(系统管理): 定时报告发送邮件附件名称过长导致展示错误 