### PR TITLE
fix(系统管理-定时报告): 定时报告选择太多视图会报错字段值长度过长，无法保存

### DIFF
--- a/backend/src/main/resources/db/migration/V39__1.14.sql
+++ b/backend/src/main/resources/db/migration/V39__1.14.sql
@@ -30,5 +30,8 @@ CREATE TABLE IF NOT EXISTS `sys_param_assist` (
     `id` BIGINT(21) NOT NULL AUTO_INCREMENT,
     `content` MEDIUMBLOB COMMENT '内容',
     PRIMARY KEY (id)
-)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
+
+ALTER TABLE `sys_task_email`
+MODIFY COLUMN `view_ids` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NULL COMMENT '关联视图' AFTER `task_id`;
 


### PR DESCRIPTION
fix(系统管理-定时报告): 定时报告选择太多视图会报错字段值长度过长，无法保存 