### PR TITLE
fix(视图): 增加副轴字体大小自动跟随仪表版放缩，修复相同字体大小主副轴实际显示大小不同的问题

### DIFF
--- a/frontend/src/components/canvas/utils/style.js
+++ b/frontend/src/components/canvas/utils/style.js
@@ -143,6 +143,13 @@ export const customStyleTrans = {
       'lineStyle': ['width']
     }
   },
+  'yAxisExt': {
+    'nameTextStyle': ['fontSize'],
+    'axisLabel': ['fontSize'],
+    'splitLine': {
+      'lineStyle': ['width']
+    }
+  },
   'split': {
     'name': ['fontSize'],
     'axisLine': {


### PR DESCRIPTION
fix(视图): 增加副轴字体大小自动跟随仪表版放缩，修复相同字体大小主副轴实际显示大小不同的问题 