### PR TITLE
fix(仪表板-下拉列表过滤器): 清空按钮触发不能重置下拉列表的全选框

### DIFF
--- a/frontend/src/components/widget/DeWidget/DeSelectGrid.vue
+++ b/frontend/src/components/widget/DeWidget/DeSelectGrid.vue
@@ -214,6 +214,8 @@ export default {
   methods: {
     clearHandler() {
       this.value = this.element.options.attrs.multiple ? [] : null
+      this.checkAll = false
+      this.isIndeterminate = false
     },
     resetDefaultValue(id) {
       if (this.inDraw && this.manualModify && this.element.id === id) {


### PR DESCRIPTION
fix(仪表板-下拉列表过滤器): 清空按钮触发不能重置下拉列表的全选框 