### PR TITLE
fix(sec): upgrade pagehelper to 5.3.1

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.github.pagehelper</groupId>
             <artifactId>pagehelper</artifactId>
-            <version>5.3.0</version>
+            <version>5.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.shiro</groupId>


### PR DESCRIPTION
Upgrade pagehelper from 5.3.0 to 5.3.1 for vulnerability fix:
       - [CVE-2022-28111](https://www.oscs1024.com/hd/MPS-2022-7189)
