### PR TITLE
fix(过滤器): 树过滤器多选模式下选择部分节点再全选对目标视图无效

### DIFF
--- a/frontend/src/components/ElTreeSelect/index.vue
+++ b/frontend/src/components/ElTreeSelect/index.vue
@@ -241,6 +241,7 @@ export default {
       if (val) {
         this.ids = this._checkSum()
         this._emitFun()
+        this.$emit('check', null, this.ids, null)
         return
       }
       this._selectClearFun()


### PR DESCRIPTION
fix(过滤器): 树过滤器多选模式下选择部分节点再全选对目标视图无效 