### PR TITLE
fix(过滤器-下拉): 选项超长鼠标悬浮显示全部

### DIFF
--- a/frontend/src/components/ElVisualSelect/index.vue
+++ b/frontend/src/components/ElVisualSelect/index.vue
@@ -27,7 +27,9 @@
       :label="item.text"
       :value="item.id"
       :class="setSelect(item.id)"
-    />
+    >
+      <span :title="item.text">{{ item.text }}</span>
+    </el-option>
   </el-select>
 </template>
 


### PR DESCRIPTION
fix(过滤器-下拉): 选项超长鼠标悬浮显示全部 