### PR TITLE
fix: 修复eslint导致的地图映射搜索不可用

### DIFF
--- a/frontend/src/views/chart/components/senior/MapMapping.vue
+++ b/frontend/src/views/chart/components/senior/MapMapping.vue
@@ -50,8 +50,10 @@
 
         <template
           slot="header"
+          slot-scope="scope"
         >
           <el-input
+            :id="scope.$index"
             v-model="keyWord"
             size="mini"
             placeholder="输入关键字搜索"


### PR DESCRIPTION
fix: 修复eslint导致的地图映射搜索不可用 