### PR TITLE
fix(移动端): 修复手机端查看仪表板原本未被遮挡的视图，放大后被遮挡了部分的问题 #3967

### DIFF
--- a/frontend/src/components/canvas/components/editor/Preview.vue
+++ b/frontend/src/components/canvas/components/editor/Preview.vue
@@ -783,14 +783,6 @@ export default {
   padding: 10px 20px 20px;
 }
 
-.mobile-dialog-css ::v-deep .el-dialog__headerbtn {
-  top: 7px
-}
-
-.mobile-dialog-css ::v-deep .el-dialog__body {
-  padding: 0px;
-}
-
 ::-webkit-scrollbar {
   width: 0px !important;
   height: 0px !important;

--- a/frontend/src/components/canvas/customComponent/UserView.vue
+++ b/frontend/src/components/canvas/customComponent/UserView.vue
@@ -1263,4 +1263,13 @@ export default {
   z-index: 2;
   display: block !important;
 }
+
+
+.mobile-dialog-css ::v-deep .el-dialog__headerbtn {
+  top: 7px
+}
+
+.mobile-dialog-css ::v-deep .el-dialog__body {
+  padding: 0px;
+}
 </style>


### PR DESCRIPTION
fix(移动端): 修复手机端查看仪表板原本未被遮挡的视图，放大后被遮挡了部分的问题 #3967 