### PR TITLE
fix: 添加必要的依赖 org.codehaus.groovy

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -106,7 +106,11 @@
             <artifactId>shiro-spring</artifactId>
             <version>${shiro.version}</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.16</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
#### What this PR does / why we need it?
在 io/dataease/auth/service/ProxyAuthService.java:[9,19] 使用了 groovy， 但却没有在pom.xml中写明依赖

