### PR TITLE
fix(仪表板): 修复Tab中页面比较小时下钻的路径被遮挡的问题 #4479

### DIFF
--- a/frontend/src/components/canvas/components/editor/Preview.vue
+++ b/frontend/src/components/canvas/components/editor/Preview.vue
@@ -786,7 +786,6 @@ export default {
 <style lang="scss" scoped>
 .bg {
   min-width: 200px;
-  min-height: 300px;
   width: 100%;
   height: 100%;
   overflow-x: hidden;


### PR DESCRIPTION
fix(仪表板): 修复Tab中页面比较小时下钻的路径被遮挡的问题 #4479 