### PR TITLE
fix: 修复选项卡组件在头部位置居中时, 无法滚动到第一个tab close #5071

### DIFF
--- a/frontend/src/components/widget/deWidget/DeTabs.vue
+++ b/frontend/src/components/widget/deWidget/DeTabs.vue
@@ -768,19 +768,17 @@ export default {
   line-height: 25px;
 }
 
-.tab-head-left ::v-deep .el-tabs__nav-scroll {
-  display: flex;
-  justify-content: flex-start;
+::v-deep .el-tabs__nav{
+  float: unset;
+  width: max-content;
 }
 
 .tab-head-right ::v-deep .el-tabs__nav-scroll {
-  display: flex;
-  justify-content: flex-end;
+  margin-left: auto;
 }
 
 .tab-head-center ::v-deep .el-tabs__nav-scroll {
-  display: flex;
-  justify-content: center;
+  margin: 0 auto;
 }
 
 .frame-mask {


### PR DESCRIPTION
#### What this PR does / why we need it?
修复了选项卡组件 nav 无法滚动到第一个 tab1 的 bug

#### Summary of your change
使用 margin 代替 flex 实现选项卡组件头部左中右对齐, 避免 nav 无法滚动 bug

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
