### PR TITLE
fix(选项卡): 包含两页符号地图时，第二页无法显示底图#5125

### DIFF
--- a/frontend/src/components/widget/deWidget/DeTabs.vue
+++ b/frontend/src/components/widget/deWidget/DeTabs.vue
@@ -25,7 +25,7 @@
       <el-tab-pane
         v-for="(item, index) in element.options.tabList"
         :key="item.name+index"
-        :lazy="false"
+        :lazy="true"
         :name="item.name"
       >
         <span slot="label">


### PR DESCRIPTION
fix(选项卡): 包含两页符号地图时，第二页无法显示底图#5125 