### PR TITLE
fix(仪表板): 修复tab组件左右移动按钮复用和编辑时被遮挡的问题 #5380

### DIFF
--- a/frontend/src/components/widget/deWidget/DeTabs.vue
+++ b/frontend/src/components/widget/deWidget/DeTabs.vue
@@ -800,4 +800,16 @@ export default {
   width: 100% !important;
 }
 
+::v-deep .el-tabs__nav-wrap {
+padding: 0 45px!important;
+}
+
+::v-deep .el-tabs__nav-prev {
+left: 25px!important
+}
+
+::v-deep .el-tabs__nav-next {
+right: 25px!important;
+}
+
 </style>


### PR DESCRIPTION
fix(仪表板): 修复tab组件左右移动按钮复用和编辑时被遮挡的问题 #5380 