### PR TITLE
fix: RDS数据源的SQL数据集制作的视图，使用时间过滤组件过滤后视图数据为空 #5431

### DIFF
--- a/backend/src/main/java/io/dataease/provider/query/mysql/MysqlQueryProvider.java
+++ b/backend/src/main/java/io/dataease/provider/query/mysql/MysqlQueryProvider.java
@@ -1065,7 +1065,7 @@ public class MysqlQueryProvider extends QueryProvider {
                 if (field.getDeType() == 1) {
                     String format = transDateFormat(request.getDateStyle(), request.getDatePattern());
                     if (field.getDeExtractType() == 0 || field.getDeExtractType() == 5 || field.getDeExtractType() == 1) {
-                        String date = String.format(MySQLConstants.STR_TO_DATE, originName, StringUtils.isNotEmpty(field.getDateFormat()) ? field.getDateFormat() : MysqlConstants.DEFAULT_DATE_FORMAT);
+                        String date = String.format(MySQLConstants.DATE_FORMAT, originName, StringUtils.isNotEmpty(field.getDateFormat()) ? field.getDateFormat() : MysqlConstants.DEFAULT_DATE_FORMAT);
                         if(request.getOperator().equals("between")){
                             whereName = date;
                         }else {


### PR DESCRIPTION
#### What this PR does / why we need it?
解决了bug #5431 