### PR TITLE
fix:清空画布时候，选中右侧的表单没有被清除和关闭

### DIFF
--- a/frontend/src/components/canvas/components/Toolbar.vue
+++ b/frontend/src/components/canvas/components/Toolbar.vue
@@ -541,6 +541,8 @@ export default {
     clearCanvas() {
       this.$store.commit('setComponentData', [])
       this.$store.commit('recordSnapshot', 'clearCanvas')
+      bus.$emit('change_panel_right_draw', false)
+      this.$store.commit('setCurComponent', { component: null, index: null })
     },
 
     handlePreviewChange() {


### PR DESCRIPTION
#### What this PR does / why we need it?
在仪表盘的时候 选中一个图表打开右侧抽屉编辑 这个时候清空画布 右侧编辑的表单不会消失
#### Summary of your change
clearCanvas() {
      this.$store.commit('setComponentData', [])
      this.$store.commit('recordSnapshot', 'clearCanvas')
      bus.$emit('change_panel_right_draw', false)
      this.$store.commit('setCurComponent', { component: null, index: null })
    }
#### Please indicate you've done the following:
增加清空当前选中component vuex的信息和关闭右侧抽屉
![1690298143673](https://github.com/dataease/dataease/assets/54138798/909d08d4-3002-4f63-b839-f8fb58917c66)

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
