### PR TITLE
解决SQL数据集直连DB2时，编写SQL必须要带schema的问题。

### DIFF
--- a/backend/src/main/java/io/dataease/dto/datasource/Db2Configuration.java
+++ b/backend/src/main/java/io/dataease/dto/datasource/Db2Configuration.java
@@ -14,10 +14,11 @@ public class Db2Configuration extends JdbcConfiguration {
 
     public String getJdbc() {
         if(StringUtils.isEmpty(extraParams.trim())){
-            return "jdbc:db2://HOSTNAME:PORT/DATABASE"
+            return "jdbc:db2://HOSTNAME:PORT/DATABASE:currentSchema=SCHEMA;"
                     .replace("HOSTNAME", getHost().trim())
                     .replace("PORT", getPort().toString().trim())
-                    .replace("DATABASE", getDataBase().trim());
+                    .replace("DATABASE", getDataBase().trim()
+                    .replace("SCHEMA",getSchema().trim()));
         }else {
             return "jdbc:hive2://HOSTNAME:PORT/DATABASE?EXTRA_PARAMS"
                     .replace("HOSTNAME", getHost().trim())


### PR DESCRIPTION
#### What this PR does / why we need it?
提升易用性，经测试连接DB2数据库后，使用SQL数据集编写SQL时。不加schema会报错
#### Summary of your change
数据集代码操作DB2时生成SQL会拼接schema，但是SQL数据集场景无法支持。所以在连接DB2时增加SCHEMA制定，
兼容了SQL数据集，同时普通数据集也不会有问题。
#### Please indicate you've done the following:
我已测试普通数据集、SQL数据集的使用场景。
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
