### PR TITLE
fix: echarts地图全屏状态切换指标无法使用#5204

### DIFF
--- a/core/frontend/src/views/chart/components/map/MapLayerController.vue
+++ b/core/frontend/src/views/chart/components/map/MapLayerController.vue
@@ -4,6 +4,7 @@
     placement="right"
     title=""
     width="150"
+    :append-to-body="false"
     trigger="click"
   >
     <i


### PR DESCRIPTION
fix: echarts地图全屏状态切换指标无法使用#5204 