### PR TITLE
fix: 折线图时间维度的图例丢失

### DIFF
--- a/core/frontend/src/views/chart/chart/line/line_antv.js
+++ b/core/frontend/src/views/chart/chart/line/line_antv.js
@@ -32,7 +32,9 @@ export function baseLineOptionAntV(plot, container, chart, action) {
   // options
   const options = {
     meta: {
-      category: 'cat'
+      category: {
+        type: 'cat'
+      }
     },
     point: {},
     theme: theme,


### PR DESCRIPTION
fix: 折线图时间维度的图例丢失 