### PR TITLE
fix: 解决view-bubblemap的前端执行npm run dev时，无法启动报错 close issue #5288

### DIFF
--- a/extensions/dataease-extensions-view/view-bubblemap/view-bubblemap-frontend/build/webpack.base.conf.js
+++ b/extensions/dataease-extensions-view/view-bubblemap/view-bubblemap-frontend/build/webpack.base.conf.js
@@ -39,7 +39,7 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
-        include: [resolve('src'), resolve('test'), resolve('node_modules/webpack-dev-server/client')]
+        include: [resolve('src'), resolve('test')]
       },
       {
         test: /\.svg$/,

--- a/extensions/dataease-extensions-view/view-bubblemap/view-bubblemap-frontend/build/webpack.dev.conf.js
+++ b/extensions/dataease-extensions-view/view-bubblemap/view-bubblemap-frontend/build/webpack.dev.conf.js
@@ -13,6 +13,7 @@ const portfinder = require('portfinder')
 const HOST = process.env.HOST
 const PORT = process.env.PORT && Number(process.env.PORT)
 
+const VueLoaderPlugin = require("vue-loader/lib/plugin");
 const devWebpackConfig = merge(baseWebpackConfig, {
   module: {
     rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap, usePostCSS: true })
@@ -45,6 +46,7 @@ const devWebpackConfig = merge(baseWebpackConfig, {
     }
   },
   plugins: [
+    new VueLoaderPlugin(),
     new webpack.DefinePlugin({
       'process.env': require('../config/dev.env')
     }),

--- a/extensions/dataease-extensions-view/view-bubblemap/view-bubblemap-frontend/package.json
+++ b/extensions/dataease-extensions-view/view-bubblemap/view-bubblemap-frontend/package.json
@@ -56,6 +56,7 @@
     "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "^2.5.2",
     "webpack": "^4.8.1",
+    "webpack-cli": "^3.3.11",
     "webpack-bundle-analyzer": "^3.3.2",
     "webpack-dev-server": "^3.1.11",
     "webpack-merge": "^4.1.0"


### PR DESCRIPTION
#### What this PR does / why we need it?
解决view-bubblemap的前端执行npm run dev时，无法启动报错 
#### Summary of your change
增加依赖，修改web-pack配置
#### Please indicate you've done the following:
- [√ ] Made sure tests are passing and test coverage is added if needed.
- [ √] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
