### PR TITLE
fix: 动态排序图中“分组/维度”使用计算字段时，视图显示异常

### DIFF
--- a/core/backend/src/main/java/io/dataease/service/chart/ChartViewService.java
+++ b/core/backend/src/main/java/io/dataease/service/chart/ChartViewService.java
@@ -451,7 +451,7 @@ public class ChartViewService {
                 List<ChartViewFieldDTO> xAxisExtList = gson.fromJson(view.getXAxisExt(), new TypeToken<List<ChartViewFieldDTO>>() {
                 }.getType());
                 xAxisExtList.forEach((x) -> {
-                    x.setExtField(1);
+                    x.setBusiType("race-bar");
                 });
                 xAxis.addAll(xAxisExtList);
             } else {
@@ -1031,7 +1031,7 @@ public class ChartViewService {
                 List<ChartViewFieldDTO> xAxisExtList = gson.fromJson(view.getXAxisExt(), new TypeToken<List<ChartViewFieldDTO>>() {
                 }.getType());
                 xAxisExtList.forEach((x) -> {
-                    x.setExtField(1);
+                    x.setBusiType("race-bar");
                 });
                 xAxis.addAll(xAxisExtList);
             }

--- a/core/frontend/src/views/chart/chart/common/common_table.js
+++ b/core/frontend/src/views/chart/chart/common/common_table.js
@@ -166,7 +166,6 @@ export function getCustomTheme(chart) {
       theme.colCell.measureText.fill = c.tableHeaderFontColor ? c.tableHeaderFontColor : c.tableFontColor
 
       // 奇数行单元格背景色
-      console.log(enableTableCrossBG, i_s_c, i_c)
       theme.dataCell.cell.crossBackgroundColor = enableTableCrossBG ? i_s_c : i_c
       theme.dataCell.cell.backgroundColor = i_c
       theme.dataCell.cell.horizontalBorderColor = b_c
@@ -228,7 +227,6 @@ export function getCustomTheme(chart) {
       theme.dataCell.measureText.textAlign = i_a
     }
   }
-  console.log(theme)
   return theme
 }
 

--- a/extensions/dataease-extensions-view/view-racebar/build.sh
+++ b/extensions/dataease-extensions-view/view-racebar/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 mvn clean package
 
-cp view-racebar-backend/target/view-racebar-backend-1.18.10.jar .
+cp view-racebar-backend/target/view-racebar-backend-1.18.12.jar .
 
-zip -r racebar.zip  ./view-racebar-backend-1.18.10.jar ./plugin.json
+zip -r racebar.zip  ./view-racebar-backend-1.18.12.jar ./plugin.json
 
-rm -f ./view-racebar-backend-1.18.10.jar
+rm -f ./view-racebar-backend-1.18.12.jar

--- a/extensions/dataease-extensions-view/view-racebar/plugin.json
+++ b/extensions/dataease-extensions-view/view-racebar/plugin.json
@@ -5,9 +5,9 @@
     "cost": 0,
     "category": "view",
     "descript": "ECharts 动态排序图插件",
-    "version": "1.18.10",
+    "version": "1.18.12",
     "creator": "DATAEASE",
     "moduleName": "view-racebar-backend",
-    "require": "1.18.10",
+    "require": "1.18.12",
     "dsType": ""
 }

--- a/extensions/dataease-extensions-view/view-racebar/view-racebar-backend/src/main/java/io/dataease/plugins/view/official/handler/RaceBarViewStatHandler.java
+++ b/extensions/dataease-extensions-view/view-racebar/view-racebar-backend/src/main/java/io/dataease/plugins/view/official/handler/RaceBarViewStatHandler.java
@@ -39,7 +39,6 @@ public class RaceBarViewStatHandler implements PluginViewStatHandler {
             PluginViewField pluginViewField = pluginViewParam.getPluginViewFields().get(i);
             if (StringUtils.equals(pluginViewField.getTypeField(), "xAxisExt")) {
                 pluginViewField.setTypeField("xAxis");
-                pluginViewField.setExtField(1);
             }
             String typeKey = pluginViewField.getTypeField();
             PluginSingleField pluginSingleField = baseService.buildField(dsType, pluginViewField, tableObj, i);

--- a/extensions/dataease-extensions-view/view-racebar/view-racebar-backend/src/main/java/io/dataease/plugins/view/official/impl/RaceBarService.java
+++ b/extensions/dataease-extensions-view/view-racebar/view-racebar-backend/src/main/java/io/dataease/plugins/view/official/impl/RaceBarService.java
@@ -134,7 +134,7 @@ public class RaceBarService extends ViewPluginService {
                 encode.put("x", i);
                 type = p.getType();
             } else if (StringUtils.equals(p.getTypeField(), "xAxis")) {
-                if (p.getExtField() == 1) {
+                if (StringUtils.equals(p.getBusiType(), "race-bar")) {
                     map.put("extIndex", i);
                 } else {
                     encode.put("y", i);

--- a/sdk/dataease-plugin-view/src/main/java/io/dataease/plugins/view/entity/PluginViewField.java
+++ b/sdk/dataease-plugin-view/src/main/java/io/dataease/plugins/view/entity/PluginViewField.java
@@ -5,11 +5,11 @@ import lombok.Data;
 import java.util.List;
 
 @Data
-public class PluginViewField extends PluginChartViewFieldBase{
+public class PluginViewField extends PluginChartViewFieldBase {
 
     private String typeField;
 
     private List<PluginChartCustomFilterItem> filter;
 
-
+    private String busiType;
 }


### PR DESCRIPTION
#6218

