### PR TITLE
fix: 修复将图表和过滤组件添加到选项卡内过滤组件的默认值筛选将不生效问题 #6777

### DIFF
--- a/core/frontend/src/components/canvas/components/editor/EditBar.vue
+++ b/core/frontend/src/components/canvas/components/editor/EditBar.vue
@@ -574,6 +574,7 @@ export default {
 
 <style lang="scss" scoped>
 .bar-main {
+  line-height: 24px;
   position: absolute;
   float: right;
   z-index: 10;

--- a/core/frontend/src/components/canvas/customComponent/UserView.vue
+++ b/core/frontend/src/components/canvas/customComponent/UserView.vue
@@ -374,7 +374,7 @@ export default {
   computed: {
     // 首次加载且非编辑状态新复制的视图，使用外部filter
     initLoad() {
-      return !(this.isEdit && this.currentCanvasNewId.includes(this.element.id)) && this.isFirstLoad && this.canvasId === 'canvas-main'
+      return !(this.isEdit && this.currentCanvasNewId.includes(this.element.id)) && this.isFirstLoad
     },
     scaleCoefficient() {
       if (this.terminal === 'pc' && !this.mobileLayoutStatus) {
@@ -422,7 +422,7 @@ export default {
     },
     filter() {
       const filter = {}
-      filter.filter = this.initLoad ? this.filters : this.cfilters
+      filter.filter = this.initLoad && this.cfilters?.length === 0 ? this.filters : this.cfilters
       filter.linkageFilters = this.element.linkageFilters
       filter.outerParamsFilters = this.element.outerParamsFilters
       filter.drill = this.drillClickDimensionList


### PR DESCRIPTION
style: 工具栏样式调整<br>fix: 修复将图表和过滤组件添加到选项卡内过滤组件的默认值筛选将不生效问题 #6777 