### PR TITLE
fix: 仅调整 Tab 组件的标签顺序未触发到仪表板的保存按钮转为可点击状态问题 #6133

### DIFF
--- a/core/frontend/src/components/canvas/components/editor/SettingMenu.vue
+++ b/core/frontend/src/components/canvas/components/editor/SettingMenu.vue
@@ -240,6 +240,9 @@ export default {
     }
   },
   methods: {
+    styleChange() {
+      this.$store.commit('canvasChange')
+    },
     openCustomSort() {
       this.showCustomSort = true
     },
@@ -251,6 +254,7 @@ export default {
       this.$nextTick(() => {
         this.showCustomSort = false
       })
+      this.styleChange()
     },
     positionAdjust() {
       bus.$emit('change_panel_right_draw', true)

--- a/core/frontend/src/components/widget/deWidget/TabStyle.vue
+++ b/core/frontend/src/components/widget/deWidget/TabStyle.vue
@@ -14,7 +14,7 @@
         label="选项卡标题"
         prop="titleShow"
       >
-        <el-checkbox v-model="styleInfo.titleHide">隐藏</el-checkbox>
+        <el-checkbox v-model="styleInfo.titleHide" @change="styleChange">隐藏</el-checkbox>
       </el-form-item>
       <template v-if="!styleInfo.titleHide">
         <el-form-item

--- a/core/frontend/src/layout/components/Topbar.vue
+++ b/core/frontend/src/layout/components/Topbar.vue
@@ -199,7 +199,7 @@ export default {
       if (this.$store.getters.uiInfo && this.$store.getters.uiInfo['ui.helpLink'] && this.$store.getters.uiInfo['ui.helpLink'].paramValue) {
         return this.$store.getters.uiInfo['ui.helpLink'].paramValue
       }
-      return 'https://dataease.io/docs/'
+      return 'https://dataease.io/docs/v1/'
     },
     /* topMenuColor() {
         return this.$store.getters.uiInfo.topMenuColor


### PR DESCRIPTION
fix: 修复隐藏Tab头部未触发保存问题<br>refactor: 帮助文档URL变更<br>fix: 仅调整 Tab 组件的标签顺序未触发到仪表板的保存按钮转为可点击状态问题 #6133 