### PR TITLE
fix(仪表板): 移动端布局复制已添加至布局中的图表会直接进入左侧无需再布置

### DIFF
--- a/core/core-frontend/src/store/modules/data-visualization/copy.ts
+++ b/core/core-frontend/src/store/modules/data-visualization/copy.ts
@@ -178,6 +178,7 @@ function deepCopyHelper(data, idMap) {
   const newComponentId = generateID()
   idMap[data.id] = newComponentId
   result.id = newComponentId
+  result.inMobile = false
   if (result.component === 'Group') {
     result.propValue.forEach((component, i) => {
       result.propValue[i] = deepCopyHelper(component, idMap)


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
