### PR TITLE
fix(视图): 修复Echarts动态排序图只显示一条数据问题

### DIFF
--- a/core/backend/src/main/java/io/dataease/service/chart/ChartViewService.java
+++ b/core/backend/src/main/java/io/dataease/service/chart/ChartViewService.java
@@ -1076,7 +1076,9 @@ public class ChartViewService {
                 xAxis.addAll(xAxisExtList);
             }
             fieldMap.put("xAxis", xAxis);
-            fieldMap.put("xAxisExt", xAxisExt);
+            if (!StringUtils.equals(view.getType(), "race-bar")) {
+                fieldMap.put("xAxisExt", xAxisExt);
+            }
             fieldMap.put("extStack", extStack);
             fieldMap.put("extBubble", extBubble);
             fieldMap.put("yAxis", yAxis);


### PR DESCRIPTION
#8733
