### PR TITLE
feat(X-Pack): 数据填报表单列表移动文件夹弹窗，没有选中时，确认按钮是禁用状态

### DIFF
--- a/core/frontend/src/views/dataFilling/form/MoveSelector.vue
+++ b/core/frontend/src/views/dataFilling/form/MoveSelector.vue
@@ -26,6 +26,7 @@
     <el-footer class="de-footer">
       <el-button @click="closeSave">{{ $t("commons.cancel") }}</el-button>
       <el-button
+        :disabled="targetGroup.id === undefined"
         type="primary"
         @click="doSave"
       >{{ $t("commons.confirm") }}


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
