### PR TITLE
fix(查询组件): 修复查询条件的选项来源设置为数据集时，数据集字段变更后，查询字段依然使用变更前的 ID，导致无法获取选项的问题

### DIFF
--- a/core/core-frontend/src/custom-component/v-query/QueryConditionConfiguration.vue
+++ b/core/core-frontend/src/custom-component/v-query/QueryConditionConfiguration.vue
@@ -740,11 +740,14 @@ const handleCondition = item => {
   handleDialogClick()
   if (activeConditionForRename.id) return
   activeCondition.value = item.id
-  curComponent.value = conditions.value.find(ele => ele.id === item.id)
+  curComponent.value = cloneDeep(conditions.value.find(ele => ele.id === item.id))
+  curComponent.value.dataset.fields = []
 
   multiple.value = curComponent.value.multiple
   if (curComponent.value.dataset.id) {
-    getOptions(curComponent.value.dataset.id, curComponent.value)
+    listFieldsWithPermissions(curComponent.value.dataset.id).then(res => {
+      curComponent.value.dataset.fields = res.data
+    })
   }
   datasetFieldList.value.forEach(ele => {
     if (!curComponent.value.checkedFieldsMap[ele.id]) {


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
