### PR TITLE
fix(查询组件): 查询组件配置 “选择数据集” 且配置参数时，筛选查询后，选项值会被两个单引号包围

### DIFF
--- a/core/core-frontend/src/hooks/web/useFilter.ts
+++ b/core/core-frontend/src/hooks/web/useFilter.ts
@@ -150,8 +150,7 @@ const getOperator = (
   conditionValueF,
   conditionValueOperatorS,
   conditionValueS,
-  firstLoad,
-  optionValueSource
+  firstLoad
 ) => {
   const valueF = firstLoad ? defaultConditionValueF : conditionValueF
   const valueS = firstLoad ? defaultConditionValueS : conditionValueS
@@ -170,11 +169,7 @@ const getOperator = (
     return valueF === '' ? operatorS : operatorF
   }
 
-  return [1, 7].includes(+displayType)
-    ? 'between'
-    : multiple || optionValueSource === 1
-    ? 'in'
-    : 'eq'
+  return [1, 7].includes(+displayType) ? 'between' : multiple ? 'in' : 'eq'
 }
 
 export const searchQuery = (queryComponentList, filter, curComponentId, firstLoad) => {
@@ -304,8 +299,7 @@ export const searchQuery = (queryComponentList, filter, curComponentId, firstLoa
                 conditionValueF,
                 conditionValueOperatorS,
                 conditionValueS,
-                firstLoad,
-                optionValueSource
+                firstLoad
               )
               if (result?.length) {
                 filter.push({


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
