### PR TITLE
refactor: 去除 DBCP2 数据库连接池，使用 HikariCP

### DIFF
--- a/core/core-backend/pom.xml
+++ b/core/core-backend/pom.xml
@@ -49,16 +49,15 @@
                     <artifactId>guava</artifactId>
                 </exclusion>
                 <exclusion>
-                    <artifactId>commons-io</artifactId>
                     <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-dbcp2</artifactId>
                 </exclusion>
             </exclusions>
             <classifier>de</classifier>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
-            <version>${commons-dbcp2.version}</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.antlr/antlr -->
         <dependency>

--- a/core/core-backend/src/main/java/io/dataease/datasource/provider/H2EngineProvider.java
+++ b/core/core-backend/src/main/java/io/dataease/datasource/provider/H2EngineProvider.java
@@ -28,7 +28,8 @@ public class H2EngineProvider extends EngineProvider {
         int queryTimeout = configuration.getQueryTimeout();
         CoreDatasource datasource = new CoreDatasource();
         BeanUtils.copyBean(datasource, engineRequest.getEngine());
-        try (Connection connection = getConnection(datasource); Statement stat = getStatement(connection, queryTimeout)) {
+        try (Connection connection = getConnection(datasource);
+             Statement stat = getStatement(connection, queryTimeout)) {
             PreparedStatement preparedStatement = connection.prepareStatement(engineRequest.getQuery());
             preparedStatement.setQueryTimeout(queryTimeout);
             Boolean result = preparedStatement.execute();

--- a/core/core-backend/src/main/java/io/dataease/datasource/provider/MysqlEngineProvider.java
+++ b/core/core-backend/src/main/java/io/dataease/datasource/provider/MysqlEngineProvider.java
@@ -26,13 +26,13 @@ import java.util.List;
 @Service("mysqlEngine")
 public class MysqlEngineProvider extends EngineProvider {
 
-
     public void exec(EngineRequest engineRequest) throws Exception {
         DatasourceConfiguration configuration = JsonUtil.parseObject(engineRequest.getEngine().getConfiguration(), Mysql.class);
         int queryTimeout = configuration.getQueryTimeout();
         CoreDatasource datasource = new CoreDatasource();
         BeanUtils.copyBean(datasource, engineRequest.getEngine());
-        try (Connection connection = getConnection(datasource); Statement stat = getStatement(connection, queryTimeout)) {
+        try (Connection connection = getConnection(datasource);
+             Statement stat = getStatement(connection, queryTimeout)) {
             PreparedStatement preparedStatement = connection.prepareStatement(engineRequest.getQuery());
             preparedStatement.setQueryTimeout(queryTimeout);
             Boolean result = preparedStatement.execute();

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <h2.version>2.2.220</h2.version>
         <knife4j.version>4.4.0</knife4j.version>
         <calcite-core.version>1.35.10</calcite-core.version>
-        <commons-dbcp2.version>2.6.0</commons-dbcp2.version>
         <antlr.version>3.5.2</antlr.version>
         <java-jwt.version>3.12.1</java-jwt.version>
         <velocity.version>2.3</velocity.version>

--- a/sdk/api/api-base/src/main/java/io/dataease/api/ds/ext/DEHikariDataSource.java
+++ b/sdk/api/api-base/src/main/java/io/dataease/api/ds/ext/DEHikariDataSource.java
@@ -1,0 +1,353 @@
+package io.dataease.api.ds.ext;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+/**
+ * DataEase HikariDataSource, supports setting the Statements' default {@code Query Timeout}.
+ *
+ * @author calvinit
+ * @date 2024/6/3 13:00
+ */
+public final class DEHikariDataSource extends HikariDataSource {
+    private static final int DEFAULT_QUERY_TIMEOUT_SECS = 30;
+    private volatile int defaultQueryTimeoutSecs;
+
+    public DEHikariDataSource() {
+        super();
+        this.defaultQueryTimeoutSecs = DEFAULT_QUERY_TIMEOUT_SECS;
+    }
+
+    public DEHikariDataSource(int defaultQueryTimeoutSecs) {
+        super();
+        this.setDefaultQueryTimeoutSecs(defaultQueryTimeoutSecs);
+    }
+
+    public int getDefaultQueryTimeoutSecs() {
+        return this.defaultQueryTimeoutSecs;
+    }
+
+    public void setDefaultQueryTimeoutSecs(int defaultQueryTimeoutSecs) {
+        if (defaultQueryTimeoutSecs < 0) {
+            defaultQueryTimeoutSecs = DEFAULT_QUERY_TIMEOUT_SECS;
+        }
+        this.defaultQueryTimeoutSecs = defaultQueryTimeoutSecs;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        Connection conn = super.getConnection();
+        if (conn == null) {
+            throw new NullPointerException("getConnection()");
+        }
+        return this.configureQueryTimeout(conn);
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return super.getConnection(username, password);
+    }
+
+    private Connection configureQueryTimeout(Connection conn) {
+        return new DEConnection(conn, this.defaultQueryTimeoutSecs);
+    }
+
+    /**
+     * DataEase Connection
+     */
+    private record DEConnection(Connection conn, int queryTimeout) implements Connection {
+
+        public Connection getRawConnection() {
+            return this.conn;
+        }
+
+        private Statement configureQueryTimeout(Statement stat) throws SQLException {
+            stat.setQueryTimeout(this.queryTimeout);
+            return stat;
+        }
+
+        private PreparedStatement configureQueryTimeout(PreparedStatement pstat) throws SQLException {
+            pstat.setQueryTimeout(this.queryTimeout);
+            return pstat;
+        }
+
+        private CallableStatement configureQueryTimeout(CallableStatement cstat) throws SQLException {
+            cstat.setQueryTimeout(this.queryTimeout);
+            return cstat;
+        }
+
+        @Override
+        public Statement createStatement() throws SQLException {
+            return this.configureQueryTimeout(this.conn.createStatement());
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql) throws SQLException {
+            return this.configureQueryTimeout(this.conn.prepareStatement(sql));
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql) throws SQLException {
+            return this.configureQueryTimeout(this.conn.prepareCall(sql));
+        }
+
+        @Override
+        public String nativeSQL(String sql) throws SQLException {
+            return this.conn.nativeSQL(sql);
+        }
+
+        @Override
+        public void setAutoCommit(boolean autoCommit) throws SQLException {
+            this.conn.setAutoCommit(autoCommit);
+        }
+
+        @Override
+        public boolean getAutoCommit() throws SQLException {
+            return this.conn.getAutoCommit();
+        }
+
+        @Override
+        public void commit() throws SQLException {
+            this.conn.commit();
+        }
+
+        @Override
+        public void rollback() throws SQLException {
+            this.conn.rollback();
+        }
+
+        @Override
+        public void close() throws SQLException {
+            this.conn.close();
+        }
+
+        @Override
+        public boolean isClosed() throws SQLException {
+            return this.conn.isClosed();
+        }
+
+        @Override
+        public DatabaseMetaData getMetaData() throws SQLException {
+            return this.conn.getMetaData();
+        }
+
+        @Override
+        public void setReadOnly(boolean readOnly) throws SQLException {
+            this.conn.setReadOnly(readOnly);
+        }
+
+        @Override
+        public boolean isReadOnly() throws SQLException {
+            return this.conn.isReadOnly();
+        }
+
+        @Override
+        public void setCatalog(String catalog) throws SQLException {
+            this.conn.setCatalog(catalog);
+        }
+
+        @Override
+        public String getCatalog() throws SQLException {
+            return this.conn.getCatalog();
+        }
+
+        @Override
+        public void setTransactionIsolation(int level) throws SQLException {
+            this.conn.setTransactionIsolation(level);
+        }
+
+        @Override
+        public int getTransactionIsolation() throws SQLException {
+            return this.conn.getTransactionIsolation();
+        }
+
+        @Override
+        public SQLWarning getWarnings() throws SQLException {
+            return this.conn.getWarnings();
+        }
+
+        @Override
+        public void clearWarnings() throws SQLException {
+            this.conn.clearWarnings();
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+            return this.configureQueryTimeout(this.conn.createStatement(resultSetType, resultSetConcurrency));
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+            return this.configureQueryTimeout(this.conn.prepareStatement(sql, resultSetType, resultSetConcurrency));
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+            return this.configureQueryTimeout(this.conn.prepareCall(sql, resultSetType, resultSetConcurrency));
+        }
+
+        @Override
+        public Map<String, Class<?>> getTypeMap() throws SQLException {
+            return this.conn.getTypeMap();
+        }
+
+        @Override
+        public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+            this.conn.setTypeMap(map);
+        }
+
+        @Override
+        public void setHoldability(int holdability) throws SQLException {
+            this.conn.setHoldability(holdability);
+        }
+
+        @Override
+        public int getHoldability() throws SQLException {
+            return this.conn.getHoldability();
+        }
+
+        @Override
+        public Savepoint setSavepoint() throws SQLException {
+            return this.conn.setSavepoint();
+        }
+
+        @Override
+        public Savepoint setSavepoint(String name) throws SQLException {
+            return this.conn.setSavepoint(name);
+        }
+
+        @Override
+        public void rollback(Savepoint savepoint) throws SQLException {
+            this.conn.rollback(savepoint);
+        }
+
+        @Override
+        public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+            this.conn.releaseSavepoint(savepoint);
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            return this.configureQueryTimeout(this.conn.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability));
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            return this.configureQueryTimeout(this.conn.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability));
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            return this.configureQueryTimeout(this.conn.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability));
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+            return this.configureQueryTimeout(this.conn.prepareStatement(sql, autoGeneratedKeys));
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+            return this.configureQueryTimeout(this.conn.prepareStatement(sql, columnIndexes));
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+            return this.configureQueryTimeout(this.conn.prepareStatement(sql, columnNames));
+        }
+
+        @Override
+        public Clob createClob() throws SQLException {
+            return this.conn.createClob();
+        }
+
+        @Override
+        public Blob createBlob() throws SQLException {
+            return this.conn.createBlob();
+        }
+
+        @Override
+        public NClob createNClob() throws SQLException {
+            return this.conn.createNClob();
+        }
+
+        @Override
+        public SQLXML createSQLXML() throws SQLException {
+            return this.conn.createSQLXML();
+        }
+
+        @Override
+        public boolean isValid(int timeout) throws SQLException {
+            return this.conn.isValid(timeout);
+        }
+
+        @Override
+        public void setClientInfo(String name, String value) throws SQLClientInfoException {
+            this.conn.setClientInfo(name, value);
+        }
+
+        @Override
+        public void setClientInfo(Properties properties) throws SQLClientInfoException {
+            this.conn.setClientInfo(properties);
+        }
+
+        @Override
+        public String getClientInfo(String name) throws SQLException {
+            return this.conn.getClientInfo(name);
+        }
+
+        @Override
+        public Properties getClientInfo() throws SQLException {
+            return this.conn.getClientInfo();
+        }
+
+        @Override
+        public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+            return this.conn.createArrayOf(typeName, elements);
+        }
+
+        @Override
+        public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+            return this.conn.createStruct(typeName, attributes);
+        }
+
+        @Override
+        public void setSchema(String schema) throws SQLException {
+            this.conn.setSchema(schema);
+        }
+
+        @Override
+        public String getSchema() throws SQLException {
+            return this.conn.getSchema();
+        }
+
+        @Override
+        public void abort(Executor executor) throws SQLException {
+            this.conn.abort(executor);
+        }
+
+        @Override
+        public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+            this.conn.setNetworkTimeout(executor, milliseconds);
+        }
+
+        @Override
+        public int getNetworkTimeout() throws SQLException {
+            return this.conn.getNetworkTimeout();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return this.conn.unwrap(iface);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return this.conn.isWrapperFor(iface);
+        }
+    }
+}


### PR DESCRIPTION
#### What this PR does / why we need it?
- Spring Boot 引入了 HikariCP 库依赖，Calcite 和项目自身 backend 模块引入了 commons-dbcp2 依赖，数据库连接池库重复多个；
- HikariCP 号称快（`光 HikariCP・A solid, high-performance, JDBC connection pool at last.`），[JMH Benchmarks](https://github.com/brettwooldridge/HikariCP-benchmark) 结果如下，使用更快的池可以优化报表的查询展示性能，提高用户体验：
![](https://github.com/brettwooldridge/HikariCP/wiki/HikariCP-bench-2.6.0.png)

#### Summary of your change
将依赖树中的 commons-dbcp2 库删除；添加 `DEHikariDatasource` 支持设置语句的 `queryTimeout`；`CalciteProvider` 的 `BasicDataSource` 替换成 `DEHikariDatasource`。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
