### PR TITLE
fix(视图): 修复动态排序图在分类对应数据量不匹配情况下排序动画可能错乱的问题

### DIFF
--- a/extensions/dataease-extensions-view/view-racebar/view-racebar-backend/src/main/java/io/dataease/plugins/view/official/impl/RaceBarService.java
+++ b/extensions/dataease-extensions-view/view-racebar/view-racebar-backend/src/main/java/io/dataease/plugins/view/official/impl/RaceBarService.java
@@ -172,6 +172,19 @@ public class RaceBarService extends ViewPluginService {
                 })
         );
 
+        Map<String, List<String>> groupXs = data.stream().collect(Collectors.toMap(
+                k -> StringUtils.defaultString(k[(Integer) map.get("extIndex")], StringUtils.EMPTY),
+                v -> {
+                    List<String> list = new ArrayList<>();
+                    list.add(v[encode.get("y")]);
+                    return list;
+                },
+                (oldList, newList) -> {
+                    oldList.addAll(newList);
+                    return oldList;
+                })
+        );
+
 
         map.put("groupData", groupData);
 
@@ -179,6 +192,7 @@ public class RaceBarService extends ViewPluginService {
 
         map.put("xs", xs);
 
+        map.put("groupXs", groupXs);
 
         return map;
     }

--- a/extensions/dataease-extensions-view/view-racebar/view-racebar-frontend/src/views/antv/racebar/index.vue
+++ b/extensions/dataease-extensions-view/view-racebar/view-racebar-frontend/src/views/antv/racebar/index.vue
@@ -480,6 +480,8 @@ export default {
           chart_option.graphic.elements[0].style.text = "";
         }
 
+        chart_option.yAxis.data = chart.data.groupXs[_currentIndex];
+
         this.currentIndex = _currentIndex;
 
         _chart.setOption(chart_option);
@@ -583,7 +585,7 @@ export default {
       }
 
       chart_option.yAxis.max = this.sliderMax;
-      chart_option.yAxis.data = chart.data.xs;
+      //chart_option.yAxis.data = chart.data.xs;
 
       chart_option.animationDurationUpdate = this.sliderTimeout;
 


### PR DESCRIPTION
#10002
