### PR TITLE
fix(图表): 修复柱线组合图修改指标显示名称后，图例没有变化的问题

### DIFF
--- a/core/core-frontend/src/views/chart/components/js/panel/charts/others/chart-mix.ts
+++ b/core/core-frontend/src/views/chart/components/js/panel/charts/others/chart-mix.ts
@@ -423,9 +423,9 @@ export class ColumnLineMix extends G2PlotChartView<DualAxesOptions, DualAxes> {
         formatter: (text: string, item: any, index: number) => {
           let name = undefined
           if (item.viewId === 'left-axes-view' && text === 'value') {
-            name = left[0]?.name
+            name = left[0]?.categories[0]
           } else if (item.viewId === 'right-axes-view' && text === 'valueExt') {
-            name = right[0]?.name
+            name = right[0]?.categories[0]
           }
           item.id = item.id + '__' + index //防止重复的图例出现问题，但是左右轴如果有相同的怎么办
           if (name === undefined) {


### PR DESCRIPTION
#10009
#10277
