### PR TITLE
fix: imgUtils中downloadCanvas报错

### DIFF
--- a/core/core-frontend/src/utils/imgUtils.ts
+++ b/core/core-frontend/src/utils/imgUtils.ts
@@ -88,6 +88,7 @@ export function downloadCanvas2(type, canvasDom, name, callBack?) {
         const a = document.createElement('a')
         a.setAttribute('download', name)
         a.href = dataUrl
+        document.body.appendChild(a)
         a.click()
         document.body.removeChild(a)
       } else {
@@ -123,6 +124,7 @@ export function downloadCanvas(type, canvasDom, name, callBack?) {
           const a = document.createElement('a')
           a.setAttribute('download', name)
           a.href = dataUrl
+          document.body.appendChild(a)
           a.click()
           document.body.removeChild(a)
         } else {


### PR DESCRIPTION
#### imgUtils中的downloadCanvas和downloadCanvas2方法，在下载生成的canvas时，创建一个a标签，触发点击后再移除。但由于移除之前没有将a标签添加到body中，导致a标签不是body的子节点，document.body.removeChild(a)报错

#### Please indicate you've done the following:

- [ Y ] Made sure tests are passing and test coverage is added if needed.
- [ Y ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ Y ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
