### PR TITLE
水波图组件在修改label格式类型时，数值和百分比切换后，label显示的数值错误

### DIFF
--- a/core/core-frontend/src/utils/imgUtils.ts
+++ b/core/core-frontend/src/utils/imgUtils.ts
@@ -88,6 +88,7 @@ export function downloadCanvas2(type, canvasDom, name, callBack?) {
         const a = document.createElement('a')
         a.setAttribute('download', name)
         a.href = dataUrl
+        document.body.appendChild(a)
         a.click()
         document.body.removeChild(a)
       } else {
@@ -123,6 +124,7 @@ export function downloadCanvas(type, canvasDom, name, callBack?) {
           const a = document.createElement('a')
           a.setAttribute('download', name)
           a.href = dataUrl
+          document.body.appendChild(a)
           a.click()
           document.body.removeChild(a)
         } else {

--- a/core/core-frontend/src/views/chart/components/js/panel/charts/liquid/liquid.ts
+++ b/core/core-frontend/src/views/chart/components/js/panel/charts/liquid/liquid.ts
@@ -118,6 +118,7 @@ export class Liquid extends G2PlotChartView<LiquidOptions, G2Liquid> {
 
   protected configLabel(chart: Chart, options: LiquidOptions): LiquidOptions {
     const customAttr = parseJson(chart.customAttr)
+    const data = chart.data.series[0].data[0]
     const originVal = options.percent
     // 数值过大图表会异常，大于 1 无意义
     if (originVal > 1) {
@@ -145,7 +146,11 @@ export class Liquid extends G2PlotChartView<LiquidOptions, G2Liquid> {
             color: label.color
           },
           formatter: () => {
-            return valueFormatter(originVal, labelFormatter)
+            if (labelFormatter.type === 'value' || labelFormatter.type === 'auto') {
+              return valueFormatter(data, labelFormatter);
+            }
+
+            return valueFormatter(options.percent, labelFormatter);
           }
         }
       }


### PR DESCRIPTION
#### 针对数值类型的格式，用百分比的值，x100 后显示，导致显示的数据错误。

#### 针对auto和value两种类型的格式，使用series中的data进行显示。针对百分比，使用percent进行处理后显示。

#### Please indicate you've done the following:

- [ Y ] Made sure tests are passing and test coverage is added if needed.
- [ Y ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ Y ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
