### PR TITLE
fix(查询组件): 组件中 “选择关联图表及字段” 的“维度”和“参数”混淆，选择“维度”后显示的仍然是“参数”的过滤数据 #12236

### DIFF
--- a/core/core-frontend/src/components/custom-password/src/CustomPassword.vue
+++ b/core/core-frontend/src/components/custom-password/src/CustomPassword.vue
@@ -1,5 +1,7 @@
 <script lang="ts" setup>
 import { useAttrs, computed } from 'vue'
+import icon_visible_outlined from '@/assets/svg/icon_visible_outlined.svg'
+import icon_invisible_outlined from '@/assets/svg/icon_invisible_outlined.svg'
 import { hIcon } from '@/components/icon-custom'
 const attrs = useAttrs()
 const props = defineProps(['modelValue'])
@@ -13,8 +15,8 @@ const value = computed({
   }
 })
 
-const iconView = hIcon('icon_visible_outlined')
-const iconHide = hIcon('icon_invisible_outlined')
+const iconView = hIcon(icon_visible_outlined)
+const iconHide = hIcon(icon_invisible_outlined)
 </script>
 
 <template>

--- a/core/core-frontend/src/components/icon-custom/index.ts
+++ b/core/core-frontend/src/components/icon-custom/index.ts
@@ -3,7 +3,7 @@ import { ElIcon } from 'element-plus-secondary'
 import Icon from './src/Icon.vue'
 const hIcon = (name: string) => {
   return h(ElIcon, null, {
-    default: () => h(Icon, { name })
+    default: () => h(name)
   })
 }
 export { Icon, hIcon }

--- a/core/core-frontend/src/components/visualization/LinkJumpSet.vue
+++ b/core/core-frontend/src/components/visualization/LinkJumpSet.vue
@@ -379,7 +379,7 @@
                                 <Icon
                                   ><component
                                     class="svg-icon"
-                                    :className="`field-icon-${fieldType[item.sourceDeType]}`"
+                                    :class="`field-icon-${fieldType[item.sourceDeType]}`"
                                     :is="iconFieldMap[fieldType[item.sourceDeType]]"
                                   ></component
                                 ></Icon>

--- a/core/core-frontend/src/custom-component/v-query/QueryConditionConfiguration.vue
+++ b/core/core-frontend/src/custom-component/v-query/QueryConditionConfiguration.vue
@@ -1574,15 +1574,15 @@ defineExpose({
                 <template v-if="curComponent.checkedFieldsMap[field.componentId]" #prefix>
                   <el-icon>
                     <Icon
-                      :className="`field-icon-${
-                        fieldType[
-                          getDetype(
-                            curComponent.checkedFieldsMap[field.componentId],
-                            Object.values(field.fields)
-                          )
-                        ]
-                      }`"
                       ><component
+                        :class="`field-icon-${
+                          fieldType[
+                            getDetype(
+                              curComponent.checkedFieldsMap[field.componentId],
+                              Object.values(field.fields)
+                            )
+                          ]
+                        }`"
                         :is="
                           iconFieldMap[
                             fieldType[

--- a/core/core-frontend/src/hooks/web/useFilter.ts
+++ b/core/core-frontend/src/hooks/web/useFilter.ts
@@ -354,14 +354,21 @@ export const searchQuery = (queryComponentList, filter, curComponentId, firstLoa
                 firstLoad
               )
               if (result?.length) {
+                const fieldId = isTree
+                  ? getFieldId(treeFieldList, result)
+                  : item.checkedFieldsMap[curComponentId]
+                const parametersFilter = parameters.reduce((pre, next) => {
+                  if (next.id === fieldId && !pre.length) {
+                    pre.push(next)
+                  }
+                  return pre
+                }, [])
                 filter.push({
                   componentId: ele.id,
-                  fieldId: isTree
-                    ? getFieldId(treeFieldList, result)
-                    : item.checkedFieldsMap[curComponentId],
+                  fieldId,
                   operator,
                   value: result,
-                  parameters,
+                  parameters: parametersFilter,
                   isTree
                 })
               }


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
