### PR TITLE
<fix>(数据集) update regex for field originName

### DIFF
--- a/core/backend/src/main/java/io/dataease/provider/engine/doris/DorisQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/engine/doris/DorisQueryProvider.java
@@ -1691,7 +1691,7 @@ public class DorisQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/engine/mysql/MysqlQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/engine/mysql/MysqlQueryProvider.java
@@ -1630,7 +1630,7 @@ public class MysqlQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/ck/CKQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/ck/CKQueryProvider.java
@@ -1742,7 +1742,7 @@ public class CKQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/db2/Db2QueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/db2/Db2QueryProvider.java
@@ -1687,7 +1687,7 @@ public class Db2QueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/es/EsQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/es/EsQueryProvider.java
@@ -1593,7 +1593,7 @@ public class EsQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/hive/HiveQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/hive/HiveQueryProvider.java
@@ -1589,7 +1589,7 @@ public class HiveQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/impala/ImpalaQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/impala/ImpalaQueryProvider.java
@@ -1584,7 +1584,7 @@ public class ImpalaQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/mongodb/MongoQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/mongodb/MongoQueryProvider.java
@@ -1403,7 +1403,7 @@ public class MongoQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/mysql/MysqlQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/mysql/MysqlQueryProvider.java
@@ -1720,7 +1720,7 @@ public class MysqlQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/oracle/OracleQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/oracle/OracleQueryProvider.java
@@ -1821,7 +1821,7 @@ public class OracleQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/pg/PgQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/pg/PgQueryProvider.java
@@ -1587,7 +1587,7 @@ public class PgQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/redshift/RedshiftQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/redshift/RedshiftQueryProvider.java
@@ -1567,7 +1567,7 @@ public class RedshiftQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/backend/src/main/java/io/dataease/provider/query/sqlserver/SqlserverQueryProvider.java
+++ b/core/backend/src/main/java/io/dataease/provider/query/sqlserver/SqlserverQueryProvider.java
@@ -1764,7 +1764,7 @@ public class SqlserverQueryProvider extends QueryProvider {
             }
             originField = originField.replaceAll("[\\t\\n\\r]]", "");
             // 正则提取[xxx]
-            String regex = "\\[(.*?)]";
+            String regex = "\\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\\]";
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(originField);
             Set<String> ids = new HashSet<>();

--- a/core/frontend/src/views/dataset/data/CalcFieldEdit.vue
+++ b/core/frontend/src/views/dataset/data/CalcFieldEdit.vue
@@ -549,7 +549,7 @@ export default {
           if (name2Auto) {
             name2Auto.push(nameIdMap[ele])
           }
-          name2Id = name2Id.replace(`[${ele}]`, `[${nameIdMap[ele]}]`)
+          name2Id = name2Id.replace(`[${ele}]`, nameIdMap[ele] ? `[${nameIdMap[ele]}]` : `[${ele}]`)
         })
       }
       return name2Id


### PR DESCRIPTION
#### What this PR does / why we need it?
计算字段无法使用带[]的函数, 如doris/mysql等JSON_EXTRACT([value],'$[1]')
![image](https://github.com/user-attachments/assets/7368511a-e52b-4f92-aa32-2c3ae361f412)
![image](https://github.com/user-attachments/assets/c85a55f7-b2f9-469f-848a-3642edc5bd0e)

解决方法:
1. 前端找不到field时保留, 后端基于uuid格式的正则匹配(fields字段的id格式为Uuid),   
2. 另外也可以使用「(.*?)」这种正则,  不使用[]等会冲突的关键字 ,
#### Summary of your change
计算字段无法使用带[]的函数, 如doris/mysql等JSON_EXTRACT([value],'$[1]')
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
