### PR TITLE
fix(图表): 修复明细表自动换行后，单元格内容右对齐时，出现内容超出当前单元格进行显示的问题

### DIFF
--- a/core/core-frontend/src/views/chart/components/editor/editor-style/components/table/TableCellSelector.vue
+++ b/core/core-frontend/src/views/chart/components/editor/editor-style/components/table/TableCellSelector.vue
@@ -388,7 +388,7 @@ onMounted(() => {
           <span style="margin-right: 4px">{{ t('chart.merge_cells') }}</span>
           <el-tooltip class="item" effect="dark" placement="bottom">
             <template #content>
-              <div>合并单元格后行列冻结会失效</div>
+              <div>合并单元格后，行列冻结、自动换行会失效。</div>
             </template>
             <el-icon class="hint-icon" :class="{ 'hint-icon--dark': themes === 'dark' }">
               <Icon name="icon_info_outlined"><icon_info_outlined class="svg-icon" /></Icon>


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
