### PR TITLE
fix(图表): 修复图表在不显示标题时，显示联动、跳转等标识的图标占用图表高度，导致图表出现抖动假相的问题 #11156 #12112

### DIFF
--- a/core/core-frontend/src/views/chart/components/views/index.vue
+++ b/core/core-frontend/src/views/chart/components/views/index.vue
@@ -879,6 +879,9 @@ const toolTip = computed(() => {
 })
 
 const marginBottom = computed<string | 0>(() => {
+  if (!titleShow.value) {
+    return 0
+  }
   if (titleShow.value || trackMenu.value.length > 0 || state.title_remark.show) {
     return 12 * scale.value + 'px'
   }
@@ -890,8 +893,22 @@ const iconSize = computed<string>(() => {
 })
 
 const titleIconStyle = computed(() => {
+  // 不显示标题时，图标的样式
+  const style = {
+    position: 'absolute',
+    color: 'rgb(255, 252, 252)',
+    position: 'absolute',
+    border: '1px solid rgb(173, 170, 170)',
+    'background-color': 'rgba(173, 170, 170)',
+    'border-radius': '2px',
+    padding: '0 2px 0 2px',
+    top: '2px',
+    'z-index': 1,
+    left: '6px'
+  }
   return {
-    color: canvasStyleData.value.component.seniorStyleSetting.linkageIconColor
+    color: canvasStyleData.value.component.seniorStyleSetting.linkageIconColor,
+    ...(titleShow.value ? {} : style)
   }
 })
 const chartHover = ref(false)


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
