### PR TITLE
fix(嵌入式): 上传自定义字体，在添加了 content-path 路径的情况下，div 嵌入数据大屏会提示字体请求不到

### DIFF
--- a/core/core-frontend/src/store/modules/appearance.ts
+++ b/core/core-frontend/src/store/modules/appearance.ts
@@ -175,7 +175,9 @@ export const useAppearanceStore = defineStore('appearanceStore', {
         fontStyleElement.innerHTML = `@font-face {
             font-family: '${name}';
             src: url(${
-              embeddedStore.baseUrl ? embeddedStore.baseUrl : basePath
+              embeddedStore.baseUrl
+                ? (embeddedStore.baseUrl + basePath).replace('/./', '/')
+                : basePath
             }/typeface/download/${currentFont.fileTransName});
             font-weight: normal;
             font-style: normal;
@@ -212,9 +214,11 @@ export const useAppearanceStore = defineStore('appearanceStore', {
       defaultFont().then(res => {
         const [font] = res || []
         setDefaultFont(
-          `${embeddedStore.baseUrl ? embeddedStore.baseUrl : basePath}/typeface/download/${
-            font?.fileTransName
-          }`,
+          `${
+            embeddedStore.baseUrl
+              ? (embeddedStore.baseUrl + basePath).replace('/./', '/')
+              : basePath
+          }/typeface/download/${font?.fileTransName}`,
           font?.name,
           font?.fileTransName
         )


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
