### PR TITLE
[fix]修复首次&升级服务脚本执行无法解析处理匿名的问题(#13882)

### DIFF
--- a/core/core-backend/src/main/resources/db/migration/V2.10.2__ddl.sql
+++ b/core/core-backend/src/main/resources/db/migration/V2.10.2__ddl.sql
@@ -5,9 +5,11 @@ DELETE ccv
 FROM core_chart_view ccv
          INNER JOIN data_visualization_info dvi ON ccv.scene_id = dvi.id
 WHERE dvi.delete_flag = 1;
+
 delete
-from data_visualization_info dvi
-where dvi.delete_flag = 1;
+from data_visualization_info
+where delete_flag = 1;
+
 DELETE
 FROM area
 where pid = '156710100'


### PR DESCRIPTION
https://github.com/dataease/dataease/issues/13882

#### What this PR does / why we need it?

安装初始化执行SQL脚本过不去，无法进行系统的安装。

#### Summary of your change
简化了delete语句，剔除dvi的匿名逻辑。

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
