### PR TITLE
fix(图表): 修复视图提示名称过长导致展示错位问题

### DIFF
--- a/core/core-frontend/src/views/chart/components/js/panel/common/common_antv.ts
+++ b/core/core-frontend/src/views/chart/components/js/panel/common/common_antv.ts
@@ -140,6 +140,7 @@ export function getTheme(chart: Chart) {
           },
           'g2-tooltip-name': {
             display: 'inline-block',
+            'line-height': tooltipFontsize + 'px',
             flex: 1
           },
           'g2-tooltip-marker': {


### PR DESCRIPTION
#14639
