### PR TITLE
fix(图表): 图表指标快速计算优化，不支持的图表指标累加功能置灰，修复了设置同环比时不能默认选择第一个同比类型、以及配置同环比后不勾选的问题

### DIFF
--- a/core/core-frontend/src/views/chart/components/editor/drag-item/components/CompareEdit.vue
+++ b/core/core-frontend/src/views/chart/components/editor/drag-item/components/CompareEdit.vue
@@ -204,7 +204,8 @@ const initFieldList = () => {
     compareItem.value.compareCalc.field = state.fieldList[0].id
   }
 }
-
+// 同环比计算类型
+const yoyLabel = ['day_mom', 'month_yoy', 'year_yoy', 'month_mom', 'year_mom']
 // 获得不同字段格式对应能计算的同环比列表
 const initCompareType = () => {
   const checkedField = state.fieldList.filter(ele => ele.id === compareItem.value.compareCalc.field)
@@ -226,12 +227,7 @@ const initCompareType = () => {
     state.compareList = []
   }
   // 如果没有选中一个同环比类型，则默认选中第一个
-  if (
-    (!compareItem.value.compareCalc.type ||
-      compareItem.value.compareCalc.type === '' ||
-      compareItem.value.compareCalc.type === 'none') &&
-    state.compareList.length > 0
-  ) {
+  if (!yoyLabel.includes(compareItem.value.compareCalc.type) && state.compareList.length > 0) {
     compareItem.value.compareCalc.type = state.compareList[0].value
   }
 }

--- a/core/core-frontend/src/views/chart/components/js/util.ts
+++ b/core/core-frontend/src/views/chart/components/js/util.ts
@@ -241,6 +241,33 @@ export function getRemark(chart) {
 }
 
 export const quotaViews = ['label', 'richTextView', 'indicator', 'gauge', 'liquid']
+// 地图
+const mapChartTypes = ['bubble-map', 'flow-map', 'heat-map', 'map', 'symbolic-map']
+// 分布图
+const distributionChartTypes = [
+  'pie',
+  'pie-donut',
+  'pie-rose',
+  'pie-donut-rose',
+  'radar',
+  'treemap',
+  'word-cloud'
+]
+// 关系图
+const relationChartTypes = ['scatter', 'quadrant', 'funnel', 'sankey', 'circle-packing']
+// 不支持指标累加的图表
+export const notSupportAccumulateViews = [
+  ...quotaViews,
+  ...mapChartTypes,
+  ...distributionChartTypes,
+  ...relationChartTypes,
+  'table-info',
+  't-heatmap',
+  'percentage-bar-stack',
+  'percentage-bar-stack-horizontal',
+  'progress-bar',
+  'stock-line'
+]
 
 export function handleEmptyDataStrategy<O extends PickOptions>(chart: Chart, options: O): O {
   const { data } = options as unknown as Options


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
