### PR TITLE
feat(图表): 去除组合图的指标排序选项

### DIFF
--- a/core/core-frontend/src/views/chart/components/editor/drag-item/QuotaItem.vue
+++ b/core/core-frontend/src/views/chart/components/editor/drag-item/QuotaItem.vue
@@ -320,9 +320,8 @@ const showSort = computed(() => {
     props.type !== 'extLabel' &&
     props.type !== 'extTooltip' &&
     props.type !== 'extBubble' &&
-    !['chart-mix', 'indicator', 'liquid', 'gauge', 'word-cloud', 'stock-line'].includes(
-      chart.value.type
-    )
+    !['indicator', 'liquid', 'gauge', 'word-cloud', 'stock-line'].includes(chart.value.type) &&
+    !chart.value.type.includes('chart-mix')
   )
 })
 


### PR DESCRIPTION
#15440

不支持指标的排序，所以去除界面选项入口