### PR TITLE
fix: 修复应用模板时，设置的数据集分组的名称与已有数据集的名称相同时， 会提示"数据集分组名称已存在" #15611

### DIFF
--- a/core/core-backend/src/main/java/io/dataease/visualization/server/DataVisualizationServer.java
+++ b/core/core-backend/src/main/java/io/dataease/visualization/server/DataVisualizationServer.java
@@ -471,6 +471,7 @@ public class DataVisualizationServer implements DataVisualizationApi {
         QueryWrapper<CoreDatasetGroup> queryWrapper = new QueryWrapper<>();
         queryWrapper.eq("name", datasetFolderName);
         queryWrapper.eq("pid", datasetFolderPid);
+        queryWrapper.eq("node_type", DataVisualizationConstants.NODE_TYPE.FOLDER);
         if (coreDatasetGroupMapper.exists(queryWrapper)) {
             return "repeat";
         } else {


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
