### PR TITLE
fix(图表): 修复组合图左轴与横轴字体设置不生效的问题

### DIFF
--- a/core/core-frontend/src/views/chart/components/js/panel/common/common_antv.ts
+++ b/core/core-frontend/src/views/chart/components/js/panel/common/common_antv.ts
@@ -489,7 +489,8 @@ export function getXAxis(chart: Chart) {
               style: {
                 fill: a.axisLabel.color,
                 fontSize: a.axisLabel.fontSize,
-                textAlign: textAlign
+                textAlign: textAlign,
+                fontFamily: chart.fontFamily
               },
               formatter: value => {
                 return chart.type === 'bidirectional-bar' && value.length > a.axisLabel.lengthLimit
@@ -594,7 +595,8 @@ export function getYAxis(chart: Chart) {
           fill: yAxis.axisLabel.color,
           fontSize: yAxis.axisLabel.fontSize,
           textBaseline,
-          textAlign
+          textAlign,
+          fontFamily: chart.fontFamily
         },
         formatter: value => {
           return value.length > yAxis.axisLabel.lengthLimit
@@ -695,7 +697,8 @@ export function getYAxisExt(chart: Chart) {
           fill: yAxis.axisLabel.color,
           fontSize: yAxis.axisLabel.fontSize,
           textBaseline,
-          textAlign
+          textAlign,
+          fontFamily: chart.fontFamily
         }
       }
     : null


### PR DESCRIPTION
#15876
