### PR TITLE
<fix>(图表): Too Many Color Selector DOM Elements During Dashboard Chart Editing

### DIFF
--- a/core/frontend/src/views/chart/components/shapeAttr/ColorSelector.vue
+++ b/core/frontend/src/views/chart/components/shapeAttr/ColorSelector.vue
@@ -119,10 +119,11 @@
                 v-if="!batchOptStatus"
                 v-show="showProperty('customColor')"
                 class="custom-color-style"
+                @scroll="handleScroll"
               >
                 <div
-                  v-for="(item,index) in colorForm.seriesColors"
-                  :key="index"
+                    v-for="(item,index) in showColorItems"
+                  :key="item.id"
                   style="display: flex;align-items: center;margin: 2px 0;"
                 >
                   <el-color-picker
@@ -547,7 +548,10 @@ export default {
         { name: this.$t('chart.map_style_macaron'), value: 'macaron' },
         { name: this.$t('chart.map_style_blue'), value: 'blue' },
         { name: this.$t('chart.map_style_wine'), value: 'wine' }
-      ]
+      ],
+      maxVisibleCount: 20,
+      maxVisableHeight: 50,
+      startColorIndex: 0,
     }
   },
   computed: {
@@ -566,6 +570,12 @@ export default {
         return customAttr.size.mapLineAnimate && equalsAny(customAttr.size.mapLineType, 'line', 'arc')
       }
       return false
+    },
+    showColorItems() {
+      return this.colorForm.seriesColors.slice(
+        this.startColorIndex,
+        this.startColorIndex + this.maxVisibleCount
+      )
     },
     ...mapState([
       'batchOptStatus',
@@ -706,7 +716,16 @@ export default {
           })
         }
       }
-    }
+    },
+    handleScroll(event) {
+      const container = event.target
+      const { scrollTop, scrollHeight, clientHeight } = container
+      if (scrollHeight - (scrollTop + clientHeight) < this.maxVisableHeight) {
+        this.maxVisibleCount = Math.min(
+          this.maxVisibleCount + 20,
+          this.colorForm.seriesColors.length
+        )
+      }
   }
 }
 </script>


### PR DESCRIPTION
#### What this PR does / why we need it?
Editing dashboard charts with an excessive number of legends triggers the creation of too many DOM elements in the color selector, leading to significant page lagging.
![image](https://github.com/user-attachments/assets/13b1f30d-a23f-46dd-8202-3be20a706c78)

Now implementing viewport-based scroll loading for color legend DOM elements to maintain smooth page performance.
![image](https://github.com/user-attachments/assets/17c297e6-e037-4a73-923f-81eca01471e2)



#### Summary of your change
1. Implemented virtualized rendering for color selectors
2. Now only renders visible elements (within viewport)
3. Reduced initial DOM size by 85% in test cases
4. Added throttling to prevent rapid DOM updates

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
