### PR TITLE
<fix>(仪表板): Implement Lazy Loading for Dashboard Charts During First Render

### DIFF
--- a/core/frontend/src/components/canvas/components/editor/ComponentWrapper.vue
+++ b/core/frontend/src/components/canvas/components/editor/ComponentWrapper.vue
@@ -2,6 +2,7 @@
   <div
     :style="getOutStyleDefault(config.style)"
     class="component component-outer"
+    :id="'wrapper_' + config.id"
     :class="{'component-active': filterActive, 'user-view': config.component === 'user-view'}"
     @click="handleClick"
     @mousedown="elementMouseDown"
@@ -17,14 +18,10 @@
       :series-id-map="seriesIdMap"
       @showViewDetails="showViewDetails"
     />
-    <div
-      :id="componentCanvasId"
-      :style="commonStyle"
-      class="main_view"
-    >
+    <div :id="componentCanvasId" :style="commonStyle" class="main_view">
       <svg-icon
         v-if="svgInnerEnable"
-        :style="{'color':config.commonBackground.innerImageColor}"
+        :style="{ color: config.commonBackground.innerImageColor }"
         class="svg-background"
         :icon-class="mainSlotSvgInner"
       />
@@ -52,9 +49,10 @@
       />
       <component
         :is="config.component"
-        v-else
+        v-else-if="renderCom"
         ref="wrapperChild"
         class="component"
+        :is-active="isActive"
         :canvas-id="canvasId"
         :out-style="config.style"
         :style="getComponentStyleDefault(config.style)"
@@ -160,8 +158,44 @@ export default {
       previewVisible: false,
       seriesIdMap: {
         id: ''
-      }
+      },
+      renderCom: false,
+      isActive: false,
     }
+  },
+
+  created() {
+    const activeViewId = this.$router?.currentRoute?.query?.activeViewId
+    if (activeViewId) {
+      this.isActive = activeViewId === this.config?.propValue?.viewId
+      this.renderCom = activeViewId === this.config?.propValue?.viewId
+      return
+    }
+    this.$nextTick(() => {
+      const that = this
+      function handleIntersection(entries, observer) {
+        entries.forEach((entry) => {
+          if (entry.intersectionRatio > 0.1) {
+            that.renderCom = true
+            that.isActive = true
+          } else {
+            that.isActive = false
+          }
+        })
+      }
+      const root = document.querySelector('#preview-main-canvas-main')
+
+      // 创建一个IntersectionObserver实例
+      const observer = new IntersectionObserver(handleIntersection, {
+        root: root, // 使用视口作为根
+        rootMargin: '0px',
+        threshold: 0.1 // 元素进入视口的10%时触发回调
+      })
+
+      // 选择需要观察的元素
+      const targetElement = document.querySelector(`#wrapper_${this.config.id}`)
+      observer.observe(targetElement)
+    })
   },
   computed: {
     filterActive() {

--- a/core/frontend/src/components/canvas/customComponent/UserView.vue
+++ b/core/frontend/src/components/canvas/customComponent/UserView.vue
@@ -364,6 +364,10 @@ export default {
     userId: {
       type: String,
       require: false
+    },
+    isActive: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -590,6 +594,15 @@ export default {
   },
 
   watch: {
+    'isActive': {
+      immediate: true,
+      handler(newVal) {
+        if (newVal && this.needUpdate) {
+          this.getData(this.element.propValue.viewId)
+          this.needUpdate = false
+        }
+      }
+    },
     'innerPadding': {
       handler: function(val1, val2) {
         if (val1 !== val2) {
@@ -632,6 +645,11 @@ export default {
           return
         }
         if (this.requestStatus === 'waiting') {
+          return
+        }
+        if (!this.isActive) {
+          this.needUpdate = true
+          this.getDataLoading = false
           return
         }
         if (newVal !== oldVal && this.$refs[this.element.propValue.id]) {

--- a/core/frontend/src/components/widget/deWidget/DeNumberRange.vue
+++ b/core/frontend/src/components/widget/deWidget/DeNumberRange.vue
@@ -161,6 +161,7 @@ export default {
   },
   beforeDestroy() {
     bus.$off('reset-default-value', this.resetDefaultValue)
+    this.destroyTimeMachine()
   },
   methods: {
     clearHandler() {


### PR DESCRIPTION
#### What this PR does / why we need it?
When the view is first loaded, rendering too many charts simultaneously may lead to noticeable page:
![image](https://github.com/user-attachments/assets/6d73d070-c6f5-41ab-941e-69f4a6aa266d)

With the newly added lazy loading feature, corresponding views will now load dynamically during scrolling:
![image](https://github.com/user-attachments/assets/b85f10d0-6976-44c1-8a3e-4a975aa9888c)


#### Summary of your change
Implemented lazy loading for chart views, ensuring that:
1. Only charts within the visible viewport are rendered initially
2. Additional charts are loaded dynamically as the user scrolls or interacts with the page
3. A placeholder skeleton is displayed during loading to maintain UI consistency

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
