### PR TITLE
fix: editMode为‘preview'时，禁用v-query的查询条件编辑功能

### DIFF
--- a/core/core-frontend/src/custom-component/v-query/Component.vue
+++ b/core/core-frontend/src/custom-component/v-query/Component.vue
@@ -64,7 +64,7 @@ const { element, view, scale } = toRefs(props)
 const { t } = useI18n()
 const vQueryRef = ref()
 const dvMainStore = dvMainStoreWithOut()
-const { curComponent, canvasViewInfo, mobileInPc, firstLoadMap } = storeToRefs(dvMainStore)
+const { curComponent, canvasViewInfo, mobileInPc, firstLoadMap, editMode } = storeToRefs(dvMainStore)
 const canEdit = ref(false)
 const queryConfig = ref()
 const defaultStyle = {
@@ -831,7 +831,7 @@ const autoStyle = computed(() => {
         <div class="container flex-align-center">
           {{ t('v_query.here_or_click') }}
           <el-button
-            :disabled="showPosition === 'preview' || mobileInPc"
+            :disabled="showPosition === 'preview' || mobileInPc || editMode === 'preview'"
             @click="addCriteriaConfigOut"
             style="font-family: inherit"
             text
@@ -865,7 +865,7 @@ const autoStyle = computed(() => {
               </div>
               <div
                 class="label-wrapper-tooltip"
-                v-if="showPosition !== 'preview' && !dvMainStore.mobileInPc"
+                v-if="showPosition !== 'preview' && !dvMainStore.mobileInPc && editMode !== 'preview'"
               >
                 <el-tooltip
                   effect="dark"


### PR DESCRIPTION
#### What this PR does / why we need it?
仪表板编辑过程中在全屏预览时，V-query组件中的过滤条件项目在hover的时候异常的展示了编辑和删除按钮
![image](https://github.com/user-attachments/assets/3d4f7c6c-d2e7-4d8a-a1e5-05d0ee5f2e47)

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
