### PR TITLE
<fix>(仪表板): Set Panel Sorting to Ascending by Name

### DIFF
--- a/core/frontend/src/views/panel/list/PanelList.vue
+++ b/core/frontend/src/views/panel/list/PanelList.vue
@@ -538,7 +538,7 @@ export default {
       rootAuth: '',
       rootDefaultAuth: 'view',
       originResourceTree: [],
-      curSortType: 'time_desc',
+      curSortType: 'name_asc',
       localSortParams: null,
       lastActiveDefaultPanelId: null, // 激活的节点 在这个节点下面动态放置子节点
       responseSource: 'panelQuery',


### PR DESCRIPTION
#### What this PR does / why we need it?
Avoid Dashboard Order is disarray when Collaborative Editing or Refresh, so set Panel Sorting to Ascending by Name:
![image](https://github.com/user-attachments/assets/9cc25aae-4bd4-4474-aa08-140b09836db3)


#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
