### PR TITLE
<fix>(仪表板): Window Export Panel Image Event For Browser Simulation or Panel Subscription

### DIFF
--- a/core/frontend/src/components/canvas/customComponent/UserView.vue
+++ b/core/frontend/src/components/canvas/customComponent/UserView.vue
@@ -710,9 +710,22 @@ export default {
     bus.$off('clear_panel_linkage', this.clearPanelLinkage)
     bus.$off('tab-canvas-change', this.tabSwitch)
     bus.$off('resolve-wait-condition', this.resolveWaitCondition)
+
+    window.removeEventListener('exportChart', this.onExportChart)
   },
   created() {
     this.refId = uuid.v1
+    window.exportChartToImage = (viewId, pixel, callback) => {
+      const event = document.createEvent('HTMLEvents');
+      event.initEvent('exportChart', false, true);
+      event.data = {
+        viewId,
+        pixel,
+        callback
+      }
+      window.dispatchEvent(event)
+    }
+    window.addEventListener('exportChart', this.onExportChart)
     if (this.element && this.element.propValue && this.element.propValue.viewId) {
       const group = this.groupFilter(this.filters)
       this.unReadyList = group.unReady
@@ -728,6 +741,30 @@ export default {
     }
   },
   methods: {
+    onExportChart(e) {
+      const { viewId, pixel, callback } = e.data
+      if (viewId !== this.element.propValue.viewId) return
+      if (this.getDataLoading) {
+        setTimeout(() => {
+          this.onExportChart(e)
+        }, 200)
+        return
+      }
+      this.$store.commit('setClickComponentStatus', true)
+      setTimeout(() => {
+        this.$store.commit('setCurComponent', { component: this.element, index: undefined })
+        this.$nextTick(() => {
+          this.openChartDetailsDialog({ openType: "enlarge" })
+          this.$nextTick(() => {
+            this.imageDownloading = true
+            this.$refs['userViewDialog'].exportViewImg(pixel || this.pixel, (url) => {
+              this.imageDownloading = false
+              if (callback) callback(url)
+            })
+          })
+        })
+      }, 200)
+    },
     resolveWaitCondition(p) {
       this.unReadyList.filter(f => f instanceof Promise && f.componentId === p.componentId).map(f => {
         f.cacheObj.cb(p)

--- a/core/frontend/src/components/canvas/utils/utils.js
+++ b/core/frontend/src/components/canvas/utils/utils.js
@@ -273,7 +273,7 @@ export function exportImgNew(imgName, callback) {
       a.click()
       document.body.removeChild(a)
       window.devicePixelRatio = originalDPR
-      callback()
+      callback(pngUrl)
     } catch (e) {
       window.devicePixelRatio = originalDPR
       callback()

--- a/core/frontend/src/views/panel/list/PanelViewShow.vue
+++ b/core/frontend/src/views/panel/list/PanelViewShow.vue
@@ -513,6 +513,16 @@ export default {
     bus.$on('set-panel-show-type', this.setPanelShowType)
     bus.$on('set-panel-share-user', this.setPanelShareUser)
     this.initPdfTemplate()
+
+    window.downloadPanelAsImage = (callback) => {
+      if (limit.activeCount) {
+        setTimeout(() => {
+          window.downloadPanelAsImage(callback)
+        }, 2000)
+        return
+      }
+      this.downloadAsImage(callback)
+    }
   },
   beforeDestroy() {
     bus.$off('set-panel-show-type', this.setPanelShowType)
@@ -717,7 +727,7 @@ export default {
       }
     },
 
-    downloadAsImage() {
+    downloadAsImage(callback) {
       this.dataLoading = true
       // 保存原始的设备像素比值
       const originalDPR = window.devicePixelRatio
@@ -730,6 +740,11 @@ export default {
           toPngUrl(canvasID, (pngUrl) => {
             try {
               this.exporting = false
+              if (typeof callback === 'function') {
+                callback(pngUrl)
+                this.dataLoading = false
+                return
+              }
               const a = document.createElement('a')
               a.setAttribute('download', this.$store.state.panel.panelInfo.name + '.png')
               a.href = pngUrl


### PR DESCRIPTION
#### What this PR does / why we need it?
For Export Panel Image when Browser Simulation or Panel Subscription:
![image](https://github.com/user-attachments/assets/3beca843-0fb2-465a-a5e1-23b881cb560d)

#### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
