### PR TITLE
fix: 引入 decimal.js 解决合计丢失精度的问题

### DIFF
--- a/core/core-frontend/package.json
+++ b/core/core-frontend/package.json
@@ -28,6 +28,7 @@
     "axios": "^1.3.3",
     "crypto-js": "^4.1.1",
     "dayjs": "^1.11.9",
+    "decimal.js": "^10.5.0",
     "echarts": "^5.5.1",
     "element-plus-secondary": "^1.0.0",
     "element-resize-detector": "^1.2.4",

--- a/core/core-frontend/src/views/chart/components/js/util.ts
+++ b/core/core-frontend/src/views/chart/components/js/util.ts
@@ -12,7 +12,7 @@ import { ElMessage } from 'element-plus-secondary'
 import { useI18n } from '@/hooks/web/useI18n'
 import { useLinkStoreWithOut } from '@/store/modules/link'
 import { useAppStoreWithOut } from '@/store/modules/app'
-import { Decimal } from "decimal.js";
+import { Decimal } from 'decimal.js'
 
 const appStore = useAppStoreWithOut()
 const isDataEaseBi = computed(() => appStore.getIsDataEaseBi)

--- a/core/core-frontend/src/views/chart/components/js/util.ts
+++ b/core/core-frontend/src/views/chart/components/js/util.ts
@@ -12,6 +12,7 @@ import { ElMessage } from 'element-plus-secondary'
 import { useI18n } from '@/hooks/web/useI18n'
 import { useLinkStoreWithOut } from '@/store/modules/link'
 import { useAppStoreWithOut } from '@/store/modules/app'
+import { Decimal } from "decimal.js";
 
 const appStore = useAppStoreWithOut()
 const isDataEaseBi = computed(() => appStore.getIsDataEaseBi)
@@ -1233,4 +1234,27 @@ export const hexToRgba = (hex, alpha = 1) => {
   const a = hexAlpha ? parseInt(hex.slice(6, 8), 16) / 255 : alpha
   // 返回 RGBA 格式
   return `rgba(${r}, ${g}, ${b}, ${a})`
+}
+
+
+// 安全计算数值字段的总和，使用 Decimal 避免浮点数精度问题
+export function safeDecimalSum(data, field) {
+  // 使用 reduce 累加所有行的指定字段值
+  return data.reduce((acc, row) => {
+    // 将字段值转换为 Decimal 类型并累加到累加器
+    return acc.plus(new Decimal(row[field] ?? 0))
+  }, new Decimal(0)).toNumber() // 最终结果转换为普通数字返回
+}
+
+// 安全计算数值字段的平均值，使用 Decimal 避免浮点数精度问题
+export function safeDecimalMean(data, field) {
+  // 如果数据为空，直接返回 0
+  if (!data.length) return 0
+  // 计算所有行的指定字段值的总和
+  const sum = data.reduce((acc, row) => {
+    // 将字段值转换为 Decimal 类型并累加到累加器
+    return acc.plus(new Decimal(row[field] ?? 0))
+  }, new Decimal(0))
+  // 将总和除以数据行数，得到平均值，并转换为普通数字返回
+  return sum.dividedBy(data.length).toNumber()
 }


### PR DESCRIPTION
#### What this PR does / why we need it?
引入 decimal.js 解决合计丢失精度的问题
#### Summary of your change
![3d1bdd10b444249d280aeb160d4ab33f](https://github.com/user-attachments/assets/5889a91f-1f9d-4e1c-ae99-516000954063)
![69f3a8e0e7056a0d7315ed800394c9ec](https://github.com/user-attachments/assets/1bf8fbc4-a0bb-4e85-a607-3b063a0de52e)
#16177 
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
