### PR TITLE
fix: close FileOutputStream to prevent resource leak in downloadFile

### DIFF
--- a/sdk/common/src/main/java/io/dataease/utils/HttpClientUtil.java
+++ b/sdk/common/src/main/java/io/dataease/utils/HttpClientUtil.java
@@ -397,11 +397,13 @@ public class HttpClientUtil {
             name.put("fileName", fileName);
             name.put("tranName", tranName);
             File localFile = new File(path + tranName);
-            FileOutputStream outputStream = new FileOutputStream(localFile);
-            byte[] buffer = new byte[4096];
-            int bytesRead;
-            while ((bytesRead = response.getEntity().getContent().read(buffer)) != -1) {
-                outputStream.write(buffer, 0, bytesRead);
+            try (InputStream is = response.getEntity().getContent();
+                 FileOutputStream outputStream = new FileOutputStream(localFile)) {
+                byte[] buffer = new byte[4096];
+                int bytesRead;
+                while ((bytesRead = is.read(buffer)) != -1) {
+                    outputStream.write(buffer, 0, bytesRead);
+                }
             }
         } catch (Exception e) {
             logger.error("HttpClient查询失败", e);


### PR DESCRIPTION
What this PR does / why we need it?
- This PR fixes a resource leak issue in the downloadFile method of HttpClientUtil.
- The FileOutputStream used for saving downloaded files was not properly closed.
- Using try-with-resources ensures that all resources are safely released, even if an exception occurs.

Summary of your change
- Refactored downloadFile to use try-with-resources for InputStream and FileOutputStream
- Ensured that all streams are properly closed to prevent resource leaks

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
