### PR TITLE
fix(图表): 修复多个tab页，提示显示错乱，会把tab2的提示显示到tab1的问题 #16271

### DIFF
--- a/core/core-frontend/src/views/chart/components/js/g2plot_tooltip_carousel.ts
+++ b/core/core-frontend/src/views/chart/components/js/g2plot_tooltip_carousel.ts
@@ -270,7 +270,8 @@ class ChartCarouselTooltip {
       this.chart.customAttr?.tooltip?.show &&
       this.chart.customAttr?.tooltip?.carousel?.enable &&
       this.values.length > 0 &&
-      this.chartIsVisible
+      this.chartIsVisible &&
+      !this.hasParentWithSwitchHidden(this.plot.chart.ele)
     )
   }
 
@@ -435,6 +436,21 @@ class ChartCarouselTooltip {
   }
 
   /**
+   * 判断元素是否有父元素包含 'switch-hidden' 类
+   * @param element
+   */
+  public hasParentWithSwitchHidden(element: HTMLElement) {
+    let parent = element.parentElement
+    while (parent) {
+      if (parent.classList.contains('switch-hidden')) {
+        return true
+      }
+      parent = parent.parentElement
+    }
+    return false
+  }
+
+  /**
    *  绑定事件监听
    *  */
   private bindEventListeners() {
@@ -475,8 +491,11 @@ class ChartCarouselTooltip {
     // 定义鼠标滚轮事件处理函数
     const handleMouseWheel = this.debounce(() => {
       CAROUSEL_MANAGER_INSTANCES?.forEach(instance => {
-        instance.paused()
-        instance.resume()
+        // 如果元素有父元素不包含 'switch-hidden' 类，则继续轮播
+        if (!this.hasParentWithSwitchHidden(instance.plot.chart.ele)) {
+          instance.paused()
+          instance.resume()
+        }
       })
     }, 50)
     // 定义 touchmove 事件处理函数（移动端）

--- a/core/core-frontend/src/views/chart/components/js/panel/common/common_antv.ts
+++ b/core/core-frontend/src/views/chart/components/js/panel/common/common_antv.ts
@@ -1784,6 +1784,10 @@ export function configPlotTooltipEvent<O extends PickOptions, P extends Plot<O>>
     if (!tooltipCtl) {
       return
     }
+    const tooltipInstance = ChartCarouselTooltip.getInstanceByContainer(chart.container)
+    if (tooltipInstance && tooltipInstance.hasParentWithSwitchHidden(plot.chart.ele)) {
+      return
+    }
     // 处理 tooltip 与下拉菜单的显示冲突问题
     const viewTrackBarElement = document.getElementById('view-track-bar-' + chart.id)
     const event = plot.chart.interactions.tooltip?.context?.event


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
