### PR TITLE
fix(calcite): 修复新建和删除数据源时空连接导致的unwrap异常,在获取CalciteConnection前增加空连接检查

### DIFF
--- a/core/core-backend/src/main/java/io/dataease/datasource/provider/CalciteProvider.java
+++ b/core/core-backend/src/main/java/io/dataease/datasource/provider/CalciteProvider.java
@@ -1597,7 +1597,8 @@ public class CalciteProvider extends Provider {
         DatasourceRequest datasourceRequest = new DatasourceRequest();
         datasourceRequest.setDsList(Map.of(datasourceSchemaDTO.getId(), datasourceSchemaDTO));
         try {
-            CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
+            Connection conn = (connection != null) ? connection : getCalciteConnection();
+            CalciteConnection calciteConnection = conn.unwrap(CalciteConnection.class);
             SchemaPlus rootSchema = buildSchema(datasourceRequest, calciteConnection);
         } catch (Exception e) {
             DEException.throwException(e.getMessage());
@@ -1633,7 +1634,8 @@ public class CalciteProvider extends Provider {
         BeanUtils.copyBean(datasourceSchemaDTO, datasource);
         datasourceSchemaDTO.setSchemaAlias(String.format(SQLConstants.SCHEMA, datasourceSchemaDTO.getId()));
         try {
-            CalciteConnection calciteConnection = connection.unwrap(CalciteConnection.class);
+            Connection conn = (connection != null) ? connection : getCalciteConnection();
+            CalciteConnection calciteConnection = conn.unwrap(CalciteConnection.class);
             SchemaPlus rootSchema = calciteConnection.getRootSchema();
             if (rootSchema.getSubSchema(datasourceSchemaDTO.getSchemaAlias()) != null) {
                 JdbcSchema jdbcSchema = rootSchema.getSubSchema(datasourceSchemaDTO.getSchemaAlias()).unwrap(JdbcSchema.class);


### PR DESCRIPTION
# 修复数据源新增/删除时的空连接报错问题

## 问题现象
在 v2.10.14 社区版中，遇到以下以下操作时会触发异常：
- 新增数据源
- 删除数据源

错误信息：
```
Cannot invoke "java.sql.Connection.unwrap(java.lang.Class)" because "this.connection" is null
```
我在 Issues 找到几个类似的问题，但是已经关闭，看着是相同问题，我引入这个几个 Issues。
#14876 
#9363 
#6555 


## 错误位置
日志指向 `CalciteProvider` 类的两个方法：
- 新增时：`update` 方法（1603 行）
- 删除时：`delete` 方法（1645 行）

均因连接对象为 `null` 时，直接调用 `unwrap(CalciteConnection.class)` 导致空指针。
### 新增数据源错误日志
```
dataease-dev  | 2025-10-23 11:25:12.251 ERROR --- [io-8100-exec-10] i.d.exception.GlobalExceptionHandler     : Method[deExceptionHandler][Cannot invoke "java.sql.Connection.unwrap(java.lang.Class)" because "this.connection" is null]
dataease-dev  | io.dataease.exception.DEException: Cannot invoke "java.sql.Connection.unwrap(java.lang.Class)" because "this.connection" is null
dataease-dev  |         at io.dataease.exception.DEException.throwException(DEException.java:38)
dataease-dev  |         at io.dataease.datasource.provider.CalciteProvider.update(CalciteProvider.java:1603)
dataease-dev  |         at io.dataease.datasource.server.DatasourceServer.save(DatasourceServer.java:351)
dataease-dev  |         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
dataease-dev  |         at java.base/java.lang.reflect.Method.invoke(Method.java:580)
dataease-dev  |         at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:354)
dataease-dev  |         at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
dataease-dev  |         at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
dataease-dev  |         at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
dataease-dev  |         at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
dataease-dev  |         at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:392)
dataease-dev  |         at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
dataease-dev  |         at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
dataease-dev  |         at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
dataease-dev  |         at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:720)
dataease-dev  |         at io.dataease.datasource.server.DatasourceServer$$SpringCGLIB$$0.save(<generated>)
dataease-dev  |         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
dataease-dev  |         at java.base/java.lang.reflect.Method.invoke(Method.java:580)
dataease-dev  |         at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:255)
dataease-dev  |         at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:188)
dataease-dev  |         at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118)
dataease-dev  |         at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:926)
dataease-dev  |         at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:831)
dataease-dev  |         at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
dataease-dev  |         at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1089)
dataease-dev  |         at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:979)
dataease-dev  |         at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)
dataease-dev  |         at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:914)
dataease-dev  |         at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:590)
dataease-dev  |         at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:885)
dataease-dev  |         at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:195)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at io.dataease.filter.HtmlResourceFilter.doFilter(HtmlResourceFilter.java:42)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at io.dataease.auth.filter.CommunityTokenFilter.doFilter(CommunityTokenFilter.java:68)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at io.dataease.license.config.LicSa.doFilter(r:108)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at io.dataease.auth.filter.TokenFilter.doFilter(TokenFilter.java:83)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
dataease-dev  |         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
dataease-dev  |         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
dataease-dev  |         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
dataease-dev  |         at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
dataease-dev  |         at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482)
dataease-dev  |         at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115)
dataease-dev  |         at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
dataease-dev  |         at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
dataease-dev  |         at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344)
dataease-dev  |         at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:389)
dataease-dev  |         at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
dataease-dev  |         at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:896)
dataease-dev  |         at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1741)
dataease-dev  |         at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
dataease-dev  |         at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1190)
dataease-dev  |         at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
dataease-dev  |         at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
dataease-dev  |         at java.base/java.lang.Thread.run(Thread.java:1583)

```

### 删除数据源错误日志
```
dataease-dev  | 2025-10-23 11:26:21.210 ERROR --- [nio-8100-exec-3] i.d.exception.GlobalExceptionHandler     : Method[deExceptionHandler][Cannot invoke "java.sql.Connection.unwrap(java.lang.Class)" because "this.connection" is null]
dataease-dev  | io.dataease.exception.DEException: Cannot invoke "java.sql.Connection.unwrap(java.lang.Class)" because "this.connection" is null
dataease-dev  |         at io.dataease.exception.DEException.throwException(DEException.java:38)
dataease-dev  |         at io.dataease.datasource.provider.CalciteProvider.delete(CalciteProvider.java:1645)
dataease-dev  |         at io.dataease.datasource.server.DatasourceServer.recursionDel(DatasourceServer.java:689)
dataease-dev  |         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
dataease-dev  |         at java.base/java.lang.reflect.Method.invoke(Method.java:580)
dataease-dev  |         at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:354)
dataease-dev  |         at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:716)
dataease-dev  |         at io.dataease.datasource.server.DatasourceServer$$SpringCGLIB$$0.recursionDel(<generated>)
dataease-dev  |         at io.dataease.datasource.server.DatasourceServer.delete(DatasourceServer.java:648)
dataease-dev  |         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
dataease-dev  |         at java.base/java.lang.reflect.Method.invoke(Method.java:580)
dataease-dev  |         at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:354)
dataease-dev  |         at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
dataease-dev  |         at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
dataease-dev  |         at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
dataease-dev  |         at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:123)
dataease-dev  |         at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:392)
dataease-dev  |         at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
dataease-dev  |         at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
dataease-dev  |         at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
dataease-dev  |         at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:720)
dataease-dev  |         at io.dataease.datasource.server.DatasourceServer$$SpringCGLIB$$0.delete(<generated>)
dataease-dev  |         at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
dataease-dev  |         at java.base/java.lang.reflect.Method.invoke(Method.java:580)
dataease-dev  |         at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:255)
dataease-dev  |         at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:188)
dataease-dev  |         at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118)
dataease-dev  |         at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:926)
dataease-dev  |         at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:831)
dataease-dev  |         at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
dataease-dev  |         at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1089)
dataease-dev  |         at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:979)
dataease-dev  |         at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)
dataease-dev  |         at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:903)
dataease-dev  |         at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:564)
dataease-dev  |         at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:885)
dataease-dev  |         at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:195)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at io.dataease.filter.HtmlResourceFilter.doFilter(HtmlResourceFilter.java:42)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at io.dataease.auth.filter.CommunityTokenFilter.doFilter(CommunityTokenFilter.java:68)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at io.dataease.license.config.LicSa.doFilter(r:108)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at io.dataease.auth.filter.TokenFilter.doFilter(TokenFilter.java:83)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
dataease-dev  |         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
dataease-dev  |         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
dataease-dev  |         at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:116)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)
dataease-dev  |         at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)
dataease-dev  |         at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:167)
dataease-dev  |         at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:90)
dataease-dev  |         at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:482)
dataease-dev  |         at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:115)
dataease-dev  |         at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:93)
dataease-dev  |         at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74)
dataease-dev  |         at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:344)
dataease-dev  |         at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:389)
dataease-dev  |         at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
dataease-dev  |         at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:896)
dataease-dev  |         at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1741)
dataease-dev  |         at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
dataease-dev  |         at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1190)
dataease-dev  |         at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659)
dataease-dev  |         at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
dataease-dev  |         at java.base/java.lang.Thread.run(Thread.java:1583)

```
## 修复方式
在上述两个方法中，获取 `CalciteConnection` 前增加空连接检查：

### 更新方法
```java
        try {
+          Connection conn = (connection != null) ? connection : getCalciteConnection();
            CalciteConnection calciteConnection = conn.unwrap(CalciteConnection.class);
            SchemaPlus rootSchema = buildSchema(datasourceRequest, calciteConnection);
        } catch (Exception e) {
            DEException.throwException(e.getMessage());
        }
```

### 删除方法
```java
        try {
+            Connection conn = (connection != null) ? connection : getCalciteConnection();
            CalciteConnection calciteConnection = conn.unwrap(CalciteConnection.class);
            SchemaPlus rootSchema = calciteConnection.getRootSchema();
            ...
        } catch (Exception e) {
            DEException.throwException(e.getMessage());
        }
```


## 验证结果

### 新增数据源
**修复前**
<img width="2137" height="1733" alt="image" src="https://github.com/user-attachments/assets/0a329450-850e-45fe-97af-7b76aa4835df" />

**修复后**
<img width="1912" height="1595" alt="image" src="https://github.com/user-attachments/assets/441c958b-ac9a-4fa6-ac64-0ad29f0efff5" />


### 删除数据源
**修复前**
<img width="2811" height="1350" alt="image" src="https://github.com/user-attachments/assets/6f5235cd-3e75-4c51-98c9-355499b12afa" />

**修复后**
<img width="2549" height="1217" alt="image" src="https://github.com/user-attachments/assets/9090c0b1-e571-4157-8845-fdfb6a135df3" />


## 环境信息
<img width="1260" height="950" alt="image" src="https://github.com/user-attachments/assets/fb57efdd-089f-43ee-b587-f4ce8c386e88" />

- 版本：DataEase v2.10.14 社区版
- 部署：源码部署 + Maven 打包 + Docker 容器化
- 存储：MySQL 8
部署配置
```yaml
version: '2.1'  
services:  
  
    dataease:  
        image: registry.cn-qingdao.aliyuncs.com/dataease/dataease:v2.3-rc1  
        container_name: dataease  
        ports:  
            - 8750:8100  
        volumes:  
            - /opt/dataease2.0/conf:/opt/apps/config
```
配置文件
```yml
server:  
    tomcat:  
        connection-timeout: 70000  
spring:  
    servlet:  
        multipart:  
            max-file-size: 500MB  
            max-request-size: 500MB  
    datasource:  
        url: jdbc:mysql://192.168.137.1/dataease?autoReconnect=false&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=convertToNull&useSSL=false&allowPublicKeyRetrieval=true  
        username: root  
        password: xxxx
```