### PR TITLE
fix(ChartComponentS2): 添加国际化支持，更新总条目文本显示

### DIFF
--- a/core/core-frontend/src/views/chart/components/views/components/ChartComponentS2.vue
+++ b/core/core-frontend/src/views/chart/components/views/components/ChartComponentS2.vue
@@ -30,6 +30,7 @@ import { useEmitt } from '@/hooks/web/useEmitt'
 import { isDashboard, trackBarStyleCheck } from '@/utils/canvasUtils'
 import { type SpreadSheet } from '@antv/s2'
 import { parseJson } from '../../js/util'
+import { useI18n } from '@/hooks/web/useI18n'
 
 const dvMainStore = dvMainStoreWithOut()
 const {
@@ -41,6 +42,7 @@ const {
   inMobile
 } = storeToRefs(dvMainStore)
 const { emitter } = useEmitt()
+const { t } = useI18n()
 
 const props = defineProps({
   element: {
@@ -724,7 +726,7 @@ const tablePageClass = computed(() => {
         @keydown.stop
         @keyup.stop
       >
-        <div>共{{ state.pageInfo.total }}条</div>
+        <div>{{ t('chart.total') }} {{ state.pageInfo.total }} {{ t('chart.items') }}</div>
         <el-pagination
           v-if="state.pageStyle !== 'general'"
           class="table-page-content"


### PR DESCRIPTION
#### What this PR does / why we need it?

  Fixes dataease/dataease#17886 by adding i18n support to ChartComponentS2 so the total count text is rendered via locale strings instead of hardcoded text.

  #### Summary of your change

  - Add internationalized label for total count in ChartComponentS2.
  - Update total count text rendering to use i18n key.

  #### Please indicate you've done the following:

  - [x] Made sure tests are passing and test coverage is added if needed.
  - [x] Made sure commit message follow the rule of Conventional Commits specification (https://www.conventionalcommits.org/).
  - [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.