### PR TITLE
fix: 圆形填充图标签选项最少保留一项

### DIFF
--- a/core/core-frontend/src/views/chart/components/editor/editor-style/components/LabelSelector.vue
+++ b/core/core-frontend/src/views/chart/components/editor/editor-style/components/LabelSelector.vue
@@ -292,7 +292,7 @@ const configCompat = (labelAttr: DeepPartial<ChartLabelAttr>) => {
   }
 }
 const checkLabelContent = contentProp => {
-  if (['funnel', 'liquid', 'circle-packing'].includes(chartType.value)) {
+  if (['funnel', 'liquid'].includes(chartType.value)) {
     return false
   }
   const propIntersection = intersection(props.propertyInner, [


### PR DESCRIPTION
- 移除 circle-packing 在 checkLabelContent 中的排除
- 使圆形填充图与饼图行为一致
- 维度、指标、占比最少保留一项，单项时置灰

Related to: 仪表板圆形填充图标签选项优化

#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
