### PR TITLE
fix(图表): 修复在edge浏览器中公共链接图表带轮播，全屏预览并放大图表查看，esc退出全屏后轮播的提示显示位置不正确的问题

### DIFF
--- a/core/core-frontend/src/views/chart/components/js/g2plot_tooltip_carousel.ts
+++ b/core/core-frontend/src/views/chart/components/js/g2plot_tooltip_carousel.ts
@@ -441,6 +441,13 @@ class ChartCarouselTooltip {
    */
   public hasParentWithSwitchHidden(element: HTMLElement) {
     let parent = element.parentElement
+    const hasViewDialogInstance = Array.from(CAROUSEL_MANAGER_INSTANCES.keys()).some(key =>
+      key.includes('viewDialog')
+    )
+    const isNotViewDialog = !this.chart.container.includes('viewDialog')
+    if (hasViewDialogInstance && isNotViewDialog) {
+      return true
+    }
     while (parent) {
       if (
         parent.classList.contains('switch-hidden') ||


### PR DESCRIPTION
#### What this PR does / why we need it?

#### Summary of your change

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
