### PR TITLE
fix(图表): 修复导出条数限制配置未生效

### DIFF
--- a/core/core-backend/src/main/java/io/dataease/chart/server/ChartDataServer.java
+++ b/core/core-backend/src/main/java/io/dataease/chart/server/ChartDataServer.java
@@ -127,15 +127,7 @@ public class ChartDataServer implements ChartDataApi {
                     }
                 });
             }
-            int curLimit = Math.toIntExact(ExportCenterUtils.getExportLimit("view"));
-            int curDsLimit = Math.toIntExact(ExportCenterUtils.getExportLimit("dataset"));
-            int viewLimit = Math.min(curLimit, curDsLimit);
-            if (ChartConstants.VIEW_RESULT_MODE.CUSTOM.equals(viewDTO.getResultMode())) {
-                Integer limitCount = viewDTO.getResultCount();
-                viewDTO.setResultCount(Math.min(viewLimit, limitCount));
-            } else {
-                viewDTO.setResultCount(viewLimit);
-            }
+            viewDTO.setResultCount(getExcelExportLimit(request.getDownloadType()));
             if (CommonConstants.VIEW_DATA_FROM.TEMPLATE.equalsIgnoreCase(viewDTO.getDataFrom())) {
                 chartViewInfo = extendDataManage.getChartDataInfo(viewDTO.getId(), viewDTO);
             } else {
@@ -154,6 +146,15 @@ public class ChartDataServer implements ChartDataApi {
             throw new RuntimeException(e);
         }
         return chartViewInfo;
+    }
+
+    private int getExcelExportLimit(String downloadType) {
+        long viewLimit = ExportCenterUtils.getExportLimit("view");
+        if ("dataset".equals(downloadType)) {
+            long datasetLimit = ExportCenterUtils.getExportLimit("dataset");
+            return Math.toIntExact(Math.min(viewLimit, datasetLimit));
+        }
+        return Math.toIntExact(viewLimit);
     }
 
 

--- a/core/core-backend/src/test/java/io/dataease/chart/server/ChartDataServerTest.java
+++ b/core/core-backend/src/test/java/io/dataease/chart/server/ChartDataServerTest.java
@@ -1,0 +1,85 @@
+package io.dataease.chart.server;
+
+import io.dataease.api.chart.request.ChartExcelRequest;
+import io.dataease.chart.constant.ChartConstants;
+import io.dataease.chart.manage.ChartDataManage;
+import io.dataease.exportCenter.manage.ExportCenterLimitManage;
+import io.dataease.exportCenter.util.ExportCenterUtils;
+import io.dataease.extensions.view.dto.ChartViewDTO;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ChartDataServerTest {
+
+    @Test
+    public void findExcelDataUsesConfiguredViewExportLimitWhenViewUsesCustomResultCount() throws Exception {
+        ChartDataServer chartDataServer = chartDataServerWithExportLimits(1_000_000L, 1_000_000L);
+
+        ChartViewDTO view = new ChartViewDTO();
+        view.setResultMode(ChartConstants.VIEW_RESULT_MODE.CUSTOM);
+        view.setResultCount(100_000);
+
+        ChartExcelRequest request = new ChartExcelRequest();
+        request.setDownloadType("view");
+        request.setViewInfo(view);
+
+        chartDataServer.findExcelData(request);
+
+        assertEquals(Integer.valueOf(1_000_000), view.getResultCount());
+    }
+
+    @Test
+    public void findExcelDataUsesViewExportLimitForViewDownloads() throws Exception {
+        ChartDataServer chartDataServer = chartDataServerWithExportLimits(1_000_000L, 100_000L);
+
+        ChartViewDTO view = new ChartViewDTO();
+        view.setResultMode(ChartConstants.VIEW_RESULT_MODE.ALL);
+        view.setResultCount(100_000);
+
+        ChartExcelRequest request = new ChartExcelRequest();
+        request.setDownloadType("view");
+        request.setViewInfo(view);
+
+        chartDataServer.findExcelData(request);
+
+        assertEquals(Integer.valueOf(1_000_000), view.getResultCount());
+    }
+
+    @Test
+    public void excelExportLimitUsesLowerLimitForDatasetDownloads() throws Exception {
+        ChartDataServer chartDataServer = chartDataServerWithExportLimits(1_000_000L, 100_000L);
+
+        int resultCount = ReflectionTestUtils.invokeMethod(chartDataServer, "getExcelExportLimit", "dataset");
+
+        assertEquals(100_000, resultCount);
+    }
+
+    private ChartDataServer chartDataServerWithExportLimits(Long viewLimit, Long datasetLimit) throws Exception {
+        ChartDataManage chartDataManage = mock(ChartDataManage.class);
+        when(chartDataManage.calcData(any(ChartViewDTO.class))).thenAnswer(invocation -> {
+            ChartViewDTO result = new ChartViewDTO();
+            Map<String, Object> data = new HashMap<>();
+            data.put("sourceData", new ArrayList<Object[]>());
+            result.setData(data);
+            return result;
+        });
+
+        ExportCenterLimitManage limitManage = new ExportCenterLimitManage();
+        ReflectionTestUtils.setField(limitManage, "viewLimit", viewLimit);
+        ReflectionTestUtils.setField(limitManage, "datasetLimit", datasetLimit);
+        new ExportCenterUtils().setExportCenterLimitManage(limitManage);
+
+        ChartDataServer chartDataServer = new ChartDataServer();
+        ReflectionTestUtils.setField(chartDataServer, "chartDataManage", chartDataManage);
+        return chartDataServer;
+    }
+}

--- a/core/core-frontend/src/views/visualized/data/dataset/index.vue
+++ b/core/core-frontend/src/views/visualized/data/dataset/index.vue
@@ -394,7 +394,6 @@ const closeExport = () => {
 
 const save = ({ logic, items, errorMessage }) => {
   table.value.id = nodeInfo.id
-  table.value.row = 100000
   table.value.filename = exportForm.value.name
   table.value.dataEaseBi = isDataEaseBi.value || appStore.getIsIframe
   if (errorMessage) {


### PR DESCRIPTION
## 关联 Issue

Fixes #18180

## 变更说明

修复图表 Excel 导出时未正确使用导出条数配置的问题。

调整后：

- 图表导出使用 `dataease.export.views.limit`
- 原始明细导出使用 `dataease.export.views.limit` 与 `dataease.export.dataset.limit` 的较小值
- 移除数据集页面遗留的固定导出条数赋值

## 验证

已新增并执行 `ChartDataServerTest`，覆盖图表导出、原始明细导出的限制取值场景。

```text
OK (3 tests)
```
