### PR TITLE
fix(图表): 修复导出后明细表分页模式变化

### DIFF
--- a/core/core-frontend/src/views/chart/components/js/util.ts
+++ b/core/core-frontend/src/views/chart/components/js/util.ts
@@ -1,4 +1,4 @@
-import { isNumber } from 'lodash-es'
+import { cloneDeep, isNumber } from 'lodash-es'
 import { DEFAULT_TITLE_STYLE } from '../editor/util/chart'
 import { equalsAny, includesAny } from '../editor/util/StringUtils'
 import { FeatureCollection } from '@antv/l7plot/dist/esm/plots/choropleth/types'
@@ -571,11 +571,15 @@ function getChartExcelTitle(preFix, viewTitle) {
 
 export const exportExcelDownload = (chart, preFix, callBack?) => {
   const excelName = getChartExcelTitle(preFix, chart.title)
+  const viewInfo = toRaw(chart)
   let request: any = {
     proxy: null,
     dvId: chart.sceneId,
     viewId: chart.id,
-    viewInfo: chart,
+    viewInfo: {
+      ...viewInfo,
+      customAttr: cloneDeep(viewInfo.customAttr)
+    },
     viewName: excelName,
     busiFlag: chart.busiFlag,
     downloadType: chart.downloadType


### PR DESCRIPTION
## 关联 Issue

Fixes #18297

## 变更说明

修复明细表使用下拉分页模式时，导出图表数据后分页模式变为翻页模式的问题。

导出时会将请求中的分页模式临时设置为 `page`。本次调整为在请求对象中隔离图表配置的 `customAttr`，避免修改仪表板中的原始图表状态。

## 验证

- 已验证导出不会修改原始图表对象的分页模式
- 已执行目标文件 ESLint 检查
