### PR TITLE
fix(查询组件): 修复清除级联父级后二级下拉未清空

### DIFF
--- a/core/core-frontend/src/custom-component/v-query/Select.vue
+++ b/core/core-frontend/src/custom-component/v-query/Select.vue
@@ -27,6 +27,7 @@ import colorTree from 'less/lib/less/tree/color.js'
 import { colorStringToHex } from '@/utils/color'
 import { isMobile } from '@/utils/utils'
 import { ElMessage } from 'element-plus-secondary'
+import { isCascadeParentCleared } from './cascade-utils'
 
 interface SelectConfig {
   selectValue: any
@@ -167,6 +168,17 @@ const setCascadeValueBack = val => {
   })
 }
 
+const clearCascadeSelectValue = () => {
+  selectValue.value = config.value.multiple ? [] : undefined
+  config.value.selectValue = cloneDeep(selectValue.value)
+  config.value.mapValue = []
+  if (props.isConfig) {
+    config.value.defaultValue = cloneDeep(selectValue.value)
+    config.value.defaultMapValue = []
+  }
+  setCascadeValueBack(config.value.mapValue)
+}
+
 const emitCascade = () => {
   cascade.value.forEach(ele => {
     let trigger = false
@@ -202,7 +214,7 @@ const getCascadeFieldId = () => {
   cascade.value.forEach(ele => {
     let condition = null
     ele.forEach(item => {
-      const [_, queryId, fieldId] = item.datasetId.split('--')
+      const [, queryId, fieldId] = item.datasetId.split('--')
       if (queryId === config.value.id && condition) {
         if (item.fieldId) {
           condition.fieldId = item.fieldId
@@ -770,6 +782,10 @@ const single = ref()
 
 const getOptionFromCascade = () => {
   if (config.value.optionValueSource !== 1 || ![0, 2, 5].includes(+config.value.displayType)) return
+  if (isCascadeParentCleared(cascade.value, config.value.id, props.isConfig)) {
+    clearCascadeSelectValue()
+    emitCascade()
+  }
   isFromRemote.value = true
   debounceOptions(1)
 }

--- a/core/core-frontend/src/custom-component/v-query/cascade-utils.ts
+++ b/core/core-frontend/src/custom-component/v-query/cascade-utils.ts
@@ -1,0 +1,36 @@
+export interface CascadeItem {
+  datasetId?: string
+  selectValue?: unknown
+  currentSelectValue?: unknown
+}
+
+export type CascadeList = CascadeItem[][]
+
+export const isEmptyCascadeValue = (value: unknown) => {
+  if (Array.isArray(value)) {
+    return value.length === 0
+  }
+  return value === undefined || value === null || value === ''
+}
+
+const getQueryId = (datasetId?: string) => {
+  return datasetId?.split('--')[1]
+}
+
+const getCascadeValue = (item: CascadeItem, isConfig: boolean) => {
+  return isConfig ? item.selectValue : item.currentSelectValue
+}
+
+export const isCascadeParentCleared = (
+  cascadeList: CascadeList,
+  queryId: string,
+  isConfig: boolean
+) => {
+  return (cascadeList || []).some(cascadeItems => {
+    const index = cascadeItems.findIndex(item => getQueryId(item.datasetId) === queryId)
+    if (index <= 0) {
+      return false
+    }
+    return isEmptyCascadeValue(getCascadeValue(cascadeItems[index - 1], isConfig))
+  })
+}


### PR DESCRIPTION
### 变更内容

- 清除级联父级下拉值时，同步清空子级下拉的已选值
- 保留父级仍有选中值时的选项刷新和有效性校验逻辑

### 问题原因

父级清空后，子级会重新按无父级过滤条件刷新选项。若原子级选中值仍存在于刷新后的选项中，现有逻辑不会清空该值。

### 验证

- `npx eslint src/custom-component/v-query/Select.vue src/custom-component/v-query/cascade-utils.ts --ext .vue,.ts`
- `npx --yes vitest@3.2.4 run /tmp/dataease-cascade-clear.spec.ts --root /tmp --config /tmp/dataease-vitest.config.ts`
- `git diff --check`

Closes #18392
