### PR TITLE
fix(数据源): 修复 API 参数重名时重命名不生效

### DIFF
--- a/core/core-backend/src/main/java/io/dataease/datasource/provider/ApiUtils.java
+++ b/core/core-backend/src/main/java/io/dataease/datasource/provider/ApiUtils.java
@@ -60,6 +60,18 @@ public class ApiUtils {
         return new SimpleDateFormat(timeFunction[1]).format(calendar.getTime());
     }
 
+    static boolean isParamFieldMatched(List<TableField> fields, TableField field, String param) {
+        if (field == null || StringUtils.isBlank(param)) {
+            return false;
+        }
+        if (StringUtils.equalsIgnoreCase(field.getName(), param)) {
+            return true;
+        }
+        boolean matchedByName = Optional.ofNullable(fields).orElseGet(ArrayList::new).stream()
+                .anyMatch(item -> StringUtils.equalsIgnoreCase(item.getName(), param));
+        return !matchedByName && StringUtils.equalsIgnoreCase(field.getOriginName(), param);
+    }
+
     public static List<DatasetTableDTO> getApiTables(DatasourceRequest datasourceRequest) throws DEException {
         List<DatasetTableDTO> tableDescs = new ArrayList<>();
         TypeReference<List<ApiDefinition>> listTypeReference = new TypeReference<List<ApiDefinition>>() {
@@ -238,7 +250,7 @@ public class ApiUtils {
                     for (ApiDefinition definition : paramsList) {
                         for (int i = 0; i < definition.getFields().size(); i++) {
                             TableField field = definition.getFields().get(i);
-                            if (field.getName().equalsIgnoreCase(param)) {
+                            if (isParamFieldMatched(definition.getFields(), field, param)) {
                                 String resultStr = execHttpRequest(true, definition, definition.getApiQueryTimeout() == null || apiDefinition.getApiQueryTimeout() <= 0 ? 10 : apiDefinition.getApiQueryTimeout(), paramsList);
                                 List<String[]> dataList = fetchResult(resultStr, definition);
                                 if (dataList.size() > 0) {
@@ -268,7 +280,7 @@ public class ApiUtils {
                         for (ApiDefinition definition : paramsList) {
                             for (int i = 0; i < definition.getFields().size(); i++) {
                                 TableField field = definition.getFields().get(i);
-                                if (field.getName().equalsIgnoreCase(param)) {
+                                if (isParamFieldMatched(definition.getFields(), field, param)) {
                                     String resultStr = execHttpRequest(true, definition, definition.getApiQueryTimeout() == null || apiDefinition.getApiQueryTimeout() <= 0 ? 10 : apiDefinition.getApiQueryTimeout(), paramsList);
                                     List<String[]> dataList = fetchResult(resultStr, definition);
                                     if (dataList.size() > 0) {
@@ -315,7 +327,7 @@ public class ApiUtils {
                     for (ApiDefinition definition : paramsList) {
                         for (int i = 0; i < definition.getFields().size(); i++) {
                             TableField field = definition.getFields().get(i);
-                            if (field.getOriginName().equalsIgnoreCase(param)) {
+                            if (isParamFieldMatched(definition.getFields(), field, param)) {
                                 String resultStr = execHttpRequest(true, definition, definition.getApiQueryTimeout() == null || apiDefinition.getApiQueryTimeout() <= 0 ? 10 : apiDefinition.getApiQueryTimeout(), paramsList);
                                 List<String[]> dataList = fetchResult(resultStr, definition);
                                 if (dataList.size() > 0) {
@@ -337,7 +349,7 @@ public class ApiUtils {
                         for (ApiDefinition definition : paramsList) {
                             for (int i = 0; i < definition.getFields().size(); i++) {
                                 TableField field = definition.getFields().get(i);
-                                if (field.getName().equalsIgnoreCase(param)) {
+                                if (isParamFieldMatched(definition.getFields(), field, param)) {
                                     String resultStr = execHttpRequest(true, definition, definition.getApiQueryTimeout() == null || apiDefinition.getApiQueryTimeout() <= 0 ? 10 : apiDefinition.getApiQueryTimeout(), paramsList);
                                     List<String[]> dataList = fetchResult(resultStr, definition);
                                     if (dataList.size() > 0) {
@@ -391,7 +403,7 @@ public class ApiUtils {
                             for (ApiDefinition definition : paramsList) {
                                 for (int i = 0; i < definition.getFields().size(); i++) {
                                     TableField field = definition.getFields().get(i);
-                                    if (field.getOriginName().equalsIgnoreCase(param)) {
+                                    if (isParamFieldMatched(definition.getFields(), field, param)) {
                                         String resultStr = execHttpRequest(false, definition, definition.getApiQueryTimeout() == null || apiDefinition.getApiQueryTimeout() <= 0 ? 10 : apiDefinition.getApiQueryTimeout(), paramsList);
                                         List<String[]> dataList = fetchResult(resultStr, definition);
                                         if (dataList.size() > 0) {
@@ -432,7 +444,7 @@ public class ApiUtils {
                                         for (ApiDefinition definition : paramsList) {
                                             for (int i = 0; i < definition.getFields().size(); i++) {
                                                 TableField field = definition.getFields().get(i);
-                                                if (field.getOriginName().equalsIgnoreCase(param)) {
+                                                if (isParamFieldMatched(definition.getFields(), field, param)) {
                                                     String resultStr = execHttpRequest(false, definition, definition.getApiQueryTimeout() == null || apiDefinition.getApiQueryTimeout() <= 0 ? 10 : apiDefinition.getApiQueryTimeout(), paramsList);
                                                     List<String[]> dataList = fetchResult(resultStr, definition);
                                                     if (dataList.size() > 0) {
@@ -462,7 +474,7 @@ public class ApiUtils {
                                             for (ApiDefinition definition : paramsList) {
                                                 for (int i = 0; i < definition.getFields().size(); i++) {
                                                     TableField field = definition.getFields().get(i);
-                                                    if (field.getOriginName().equalsIgnoreCase(param)) {
+                                                    if (isParamFieldMatched(definition.getFields(), field, param)) {
                                                         String resultStr = execHttpRequest(false, definition, definition.getApiQueryTimeout() == null || apiDefinition.getApiQueryTimeout() <= 0 ? 10 : apiDefinition.getApiQueryTimeout(), paramsList);
                                                         List<String[]> dataList = fetchResult(resultStr, definition);
                                                         if (dataList.size() > 0) {

--- a/core/core-backend/src/test/java/io/dataease/datasource/provider/ApiUtilsTest.java
+++ b/core/core-backend/src/test/java/io/dataease/datasource/provider/ApiUtilsTest.java
@@ -1,0 +1,65 @@
+package io.dataease.datasource.provider;
+
+import io.dataease.extensions.datasource.dto.TableField;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ApiUtilsTest {
+
+    @Test
+    public void paramFieldMatchUsesRenamedFieldNameWhenOriginNameIsDuplicated() {
+        TableField firstField = tableField("id1", "id");
+        TableField secondField = tableField("id2", "id");
+        List<TableField> fields = Arrays.asList(firstField, secondField);
+
+        assertTrue(ApiUtils.isParamFieldMatched(fields, firstField, "id1"));
+        assertFalse(ApiUtils.isParamFieldMatched(fields, firstField, "id2"));
+        assertTrue(ApiUtils.isParamFieldMatched(fields, secondField, "id2"));
+        assertFalse(ApiUtils.isParamFieldMatched(fields, secondField, "id1"));
+    }
+
+    @Test
+    public void paramFieldMatchKeepsOriginNameFallbackForSavedConfigurations() {
+        TableField field = tableField("id1", "id");
+
+        assertTrue(ApiUtils.isParamFieldMatched(Arrays.asList(field), field, "id"));
+    }
+
+    @Test
+    public void paramFieldMatchPrefersRenamedFieldNameOverAnotherFieldOriginName() {
+        TableField renamedField = tableField("id", "user_id");
+        TableField originNameField = tableField("name", "id");
+        List<TableField> fields = Arrays.asList(renamedField, originNameField);
+
+        assertTrue(ApiUtils.isParamFieldMatched(
+                fields,
+                renamedField,
+                "id"
+        ));
+        assertFalse(ApiUtils.isParamFieldMatched(
+                fields,
+                originNameField,
+                "id"
+        ));
+    }
+
+    @Test
+    public void paramFieldMatchHandlesEmptyValues() {
+        TableField field = tableField("id1", "id");
+
+        assertFalse(ApiUtils.isParamFieldMatched(Arrays.asList(field), field, ""));
+        assertFalse(ApiUtils.isParamFieldMatched(null, null, "id1"));
+    }
+
+    private TableField tableField(String name, String originName) {
+        TableField field = new TableField();
+        field.setName(name);
+        field.setOriginName(originName);
+        return field;
+    }
+}

--- a/core/core-frontend/src/views/visualized/data/datasource/form/ApiKeyValue.vue
+++ b/core/core-frontend/src/views/visualized/data/datasource/form/ApiKeyValue.vue
@@ -3,10 +3,11 @@ import icon_drag_outlined from '@/assets/svg/icon_drag_outlined.svg'
 import icon_deleteTrash_outlined from '@/assets/svg/icon_delete-trash_outlined.svg'
 import icon_add_outlined from '@/assets/svg/icon_add_outlined.svg'
 import { propTypes } from '@/utils/propTypes'
-import { computed, onBeforeMount, PropType, toRefs, inject } from 'vue'
+import { computed, onBeforeMount, PropType, toRefs } from 'vue'
 import { useI18n } from '@/hooks/web/useI18n'
 import { KeyValue } from './ApiTestModel.js'
 import draggable from 'vuedraggable'
+import { getApiParamFieldKey, getApiParamFieldValue } from './api-param-field'
 
 export interface Item {
   name: string
@@ -39,10 +40,6 @@ const { t } = useI18n()
 const keyText = computed(() => {
   return props.keyPlaceholder || t('datasource.key')
 })
-const valueText = computed(() => {
-  return props.valuePlaceholder || t('datasource.value')
-})
-
 const { suggestions, items } = toRefs(props)
 
 onBeforeMount(() => {
@@ -55,8 +52,6 @@ onBeforeMount(() => {
     }
   }
 })
-
-const activeName = inject('api-active-name')
 
 const remove = (index: number) => {
   if (isDisable()) return
@@ -183,10 +178,10 @@ const timeFunLists = [
                 style="width: 100%"
               >
                 <el-option
-                  v-for="item in valueList"
-                  :key="item.originName"
+                  v-for="(item, index) in valueList"
+                  :key="getApiParamFieldKey(item, index)"
                   :label="item.name"
-                  :value="item.originName"
+                  :value="getApiParamFieldValue(item)"
                 />
               </el-select>
               <el-select

--- a/core/core-frontend/src/views/visualized/data/datasource/form/ApiVariable.vue
+++ b/core/core-frontend/src/views/visualized/data/datasource/form/ApiVariable.vue
@@ -3,11 +3,12 @@ import icon_drag_outlined from '@/assets/svg/icon_drag_outlined.svg'
 import icon_deleteTrash_outlined from '@/assets/svg/icon_delete-trash_outlined.svg'
 import icon_add_outlined from '@/assets/svg/icon_add_outlined.svg'
 import { propTypes } from '@/utils/propTypes'
-import { computed, onBeforeMount, PropType, toRefs, inject } from 'vue'
+import { computed, onBeforeMount, PropType, toRefs } from 'vue'
 import { useI18n } from '@/hooks/web/useI18n'
 import { KeyValue } from './ApiTestModel.js'
 import { guid } from '@/views/visualized/data/dataset/form/util'
 import draggable from 'vuedraggable'
+import { getApiParamFieldKey, getApiParamFieldValue } from './api-param-field'
 
 export interface Item {
   name: string
@@ -39,10 +40,6 @@ const { t } = useI18n()
 const keyText = computed(() => {
   return props.keyPlaceholder || t('datasource.key')
 })
-const valueText = computed(() => {
-  return props.valuePlaceholder || t('datasource.value')
-})
-
 const { parameters, suggestions } = toRefs(props)
 
 onBeforeMount(() => {
@@ -103,7 +100,6 @@ const createFilter = (queryString: string) => {
 const changeNameType = element => {
   element.value = ''
 }
-const activeName = inject('api-active-name')
 const options = [
   {
     label: t('data_source.parameter'),
@@ -225,10 +221,10 @@ const timeFunLists = [
                 style="width: 100%"
               >
                 <el-option
-                  v-for="item in valueList"
-                  :key="item.originName"
+                  v-for="(item, index) in valueList"
+                  :key="getApiParamFieldKey(item, index)"
                   :label="item.name"
-                  :value="item.originName"
+                  :value="getApiParamFieldValue(item)"
                 />
               </el-select>
               <el-select

--- a/core/core-frontend/src/views/visualized/data/datasource/form/api-param-field.ts
+++ b/core/core-frontend/src/views/visualized/data/datasource/form/api-param-field.ts
@@ -1,0 +1,12 @@
+interface ApiParamField {
+  name?: string
+  originName?: string
+}
+
+export const getApiParamFieldValue = (field: ApiParamField) => {
+  return field?.name || field?.originName || ''
+}
+
+export const getApiParamFieldKey = (field: ApiParamField, index: number) => {
+  return `${getApiParamFieldValue(field)}-${index}`
+}


### PR DESCRIPTION
### 变更内容

- API 参数字段下拉使用重命名后的字段名作为选项值，避免原始字段名重复时选项联动选中
- Header、Query、Body 参数配置统一使用相同的参数字段取值逻辑
- 后端 API 参数解析优先按重命名字段名匹配，未命中时再按原始字段名兼容旧配置
- 增加参数字段匹配单元测试

### 问题原因

API 参数字段下拉使用 `originName` 作为选项值。当多个参数字段的原始字段名相同、但已重命名为不同字段名时，前端会把这些选项识别为同一个值，导致选择任意一个都会选中全部。

同时，后端解析参数字段时存在 `name` 和 `originName` 混用的情况，可能导致重命名后的字段无法稳定匹配。

### 验证

- `JUnitCore io.dataease.datasource.provider.ApiUtilsTest`
- `npx --yes vitest@3.2.4 run /tmp/dataease-api-param-field.spec.ts --root /tmp --config /tmp/dataease-vitest.config.ts`
- `npx eslint src/views/visualized/data/datasource/form/ApiKeyValue.vue src/views/visualized/data/datasource/form/ApiVariable.vue src/views/visualized/data/datasource/form/api-param-field.ts --ext .vue,.ts`
- `git diff --check`

Closes #18358
