### PR TITLE
fix(图表): 修复柱线组合图同字段提示格式串用

### DIFF
--- a/core/core-frontend/src/views/chart/components/js/panel/charts/others/chart-mix-tooltip.ts
+++ b/core/core-frontend/src/views/chart/components/js/panel/charts/others/chart-mix-tooltip.ts
@@ -1,0 +1,31 @@
+type MixTooltipItem = {
+  name?: string
+  data?: {
+    quotaList?: Array<{ id?: string }>
+    valueExt?: unknown
+  }
+}
+
+type MixTooltipAxisType = 'yAxis' | 'yAxisExt'
+
+function getMixTooltipAxisType(item: MixTooltipItem): MixTooltipAxisType {
+  if (
+    item?.name === 'valueExt' ||
+    Object.prototype.hasOwnProperty.call(item?.data ?? {}, 'valueExt')
+  ) {
+    return 'yAxisExt'
+  }
+  return 'yAxis'
+}
+
+export function getMixTooltipFormatter<T>(
+  formatterMap: Record<string, T>,
+  item: MixTooltipItem
+): T | undefined {
+  const fieldId = item?.data?.quotaList?.[0]?.id
+  if (!fieldId) {
+    return undefined
+  }
+  const axisType = getMixTooltipAxisType(item)
+  return formatterMap[`${fieldId}-${axisType}`] ?? formatterMap[fieldId]
+}

--- a/core/core-frontend/src/views/chart/components/js/panel/charts/others/chart-mix.ts
+++ b/core/core-frontend/src/views/chart/components/js/panel/charts/others/chart-mix.ts
@@ -44,6 +44,7 @@ import {
 import type { Options } from '@antv/g2plot/esm'
 import { Group } from '@antv/g-canvas'
 import { extremumEvt } from '@/views/chart/components/js/extremumUitl'
+import { getMixTooltipFormatter } from './chart-mix-tooltip'
 
 const { t } = useI18n()
 const DEFAULT_DATA = []
@@ -541,7 +542,7 @@ export class ColumnLineMix extends G2PlotChartView<DualAxesOptions, DualAxes> {
     const formatterMap = tooltipAttr.seriesTooltipFormatter
       ?.filter(i => i.show)
       .reduce((pre, next) => {
-        pre[next.id] = next
+        pre[next.seriesId ?? next.id] = next
         return pre
       }, {}) as Record<string, SeriesFormatter>
     const tooltip: DualAxesOptions['tooltip'] = {
@@ -557,15 +558,16 @@ export class ColumnLineMix extends G2PlotChartView<DualAxesOptions, DualAxes> {
           return originalItems
         }
         const result = []
-        originalItems
-          .filter(item => formatterMap[item.data.quotaList[0].id])
-          .forEach(item => {
-            const formatter = formatterMap[item.data.quotaList[0].id]
-            const value = valueFormatter(parseFloat(item.value as string), formatter.formatterCfg)
-            const name = item.data.category
+        originalItems.forEach(item => {
+          const formatter = getMixTooltipFormatter(formatterMap, item)
+          if (!formatter) {
+            return
+          }
+          const value = valueFormatter(parseFloat(item.value as string), formatter.formatterCfg)
+          const name = item.data.category
 
-            result.push({ ...item, name, value })
-          })
+          result.push({ ...item, name, value })
+        })
         head.data.dynamicTooltipValue?.forEach(item => {
           const formatter = formatterMap[item.fieldId]
           if (formatter) {


### PR DESCRIPTION
### 变更内容
- 修复柱线组合图中同一指标同时放入左右轴时，提示格式互相影响的问题。
- 提示格式优先按 `seriesId` 区分 `yAxis` 和 `yAxisExt`，避免同字段配置被覆盖。
- 保留按字段 `id` 匹配的回退逻辑，兼容旧配置。
- 动态提示字段仍沿用原有 `fieldId` 匹配逻辑。

### 关联 Issue
Fixes #18403

### 验证
- `npx eslint src/views/chart/components/js/panel/charts/others/chart-mix.ts src/views/chart/components/js/panel/charts/others/chart-mix-tooltip.ts --ext .ts`
- 已验证同字段左右轴分别匹配 `字段ID-yAxis` 与 `字段ID-yAxisExt`
- `git diff --check`
