### PR TITLE
feat(查询组件): 增加年初至上月末动态时间范围

### DIFF
--- a/core/core-frontend/src/custom-component/v-query/ConditionDefaultConfiguration.vue
+++ b/core/core-frontend/src/custom-component/v-query/ConditionDefaultConfiguration.vue
@@ -229,6 +229,10 @@ const relativeToCurrentListRange = computed(() => {
         {
           label: t('common.to_this_month'),
           value: 'YearToThisMonth'
+        },
+        {
+          label: t('v_query.year_to_last_month_end'),
+          value: 'YearToLastMonthEnd'
         }
       ]
       break
@@ -262,6 +266,10 @@ const relativeToCurrentListRange = computed(() => {
         {
           label: t('v_query.year_to_date'),
           value: 'yearBeginning'
+        },
+        {
+          label: t('v_query.year_to_last_month_end'),
+          value: 'YearToLastMonthEnd'
         },
         {
           label: t('common.month_to_yesterday'),

--- a/core/core-frontend/src/custom-component/v-query/FilterTime.vue
+++ b/core/core-frontend/src/custom-component/v-query/FilterTime.vue
@@ -217,6 +217,10 @@ const relativeToCurrentListRange = computed(() => {
         {
           label: t('common.to_this_month'),
           value: 'YearToThisMonth'
+        },
+        {
+          label: t('v_query.year_to_last_month_end'),
+          value: 'YearToLastMonthEnd'
         }
       ]
       break
@@ -242,6 +246,10 @@ const relativeToCurrentListRange = computed(() => {
         {
           label: t('v_query.year_to_date'),
           value: 'yearBeginning'
+        },
+        {
+          label: t('v_query.year_to_last_month_end'),
+          value: 'YearToLastMonthEnd'
         },
         {
           label: t('common.month_to_yesterday'),

--- a/core/core-frontend/src/custom-component/v-query/QueryConditionConfiguration.vue
+++ b/core/core-frontend/src/custom-component/v-query/QueryConditionConfiguration.vue
@@ -2184,6 +2184,10 @@ const relativeToCurrentListRange = computed(() => {
         {
           label: t('common.to_this_month'),
           value: 'YearToThisMonth'
+        },
+        {
+          label: t('v_query.year_to_last_month_end'),
+          value: 'YearToLastMonthEnd'
         }
       ]
       break
@@ -2209,6 +2213,10 @@ const relativeToCurrentListRange = computed(() => {
         {
           label: t('v_query.year_to_date'),
           value: 'yearBeginning'
+        },
+        {
+          label: t('v_query.year_to_last_month_end'),
+          value: 'YearToLastMonthEnd'
         },
         {
           label: t('common.month_to_yesterday'),

--- a/core/core-frontend/src/custom-component/v-query/RangeFilterTime.vue
+++ b/core/core-frontend/src/custom-component/v-query/RangeFilterTime.vue
@@ -228,6 +228,10 @@ const relativeToCurrentListRange = computed(() => {
         {
           label: t('common.to_this_month'),
           value: 'YearToThisMonth'
+        },
+        {
+          label: t('v_query.year_to_last_month_end'),
+          value: 'YearToLastMonthEnd'
         }
       ]
       break
@@ -253,6 +257,10 @@ const relativeToCurrentListRange = computed(() => {
         {
           label: t('v_query.year_to_date'),
           value: 'yearBeginning'
+        },
+        {
+          label: t('v_query.year_to_last_month_end'),
+          value: 'YearToLastMonthEnd'
         },
         {
           label: t('common.month_to_yesterday'),

--- a/core/core-frontend/src/custom-component/v-query/time-format-dayjs.ts
+++ b/core/core-frontend/src/custom-component/v-query/time-format-dayjs.ts
@@ -1,11 +1,23 @@
 import dayjs from 'dayjs'
-import type { ManipulateType } from 'dayjs'
-function getThisStart(val = 'month' as ManipulateType | 'quarter') {
-  return new Date(dayjs().startOf(val).format('YYYY/MM/DD HH:mm:ss'))
+import type { ManipulateType, QUnitType } from 'dayjs'
+import quarterOfYear from 'dayjs/plugin/quarterOfYear'
+type ManipulateTypeWithQuarter = ManipulateType | 'quarter'
+dayjs.extend(quarterOfYear)
+
+function getThisStart(val = 'month' as ManipulateTypeWithQuarter) {
+  return new Date(
+    dayjs()
+      .startOf(val as QUnitType)
+      .format('YYYY/MM/DD HH:mm:ss')
+  )
 }
 
-function getThisEnd(val = 'month' as ManipulateType | 'quarter') {
-  return new Date(dayjs().endOf(val).format('YYYY/MM/DD HH:mm:ss'))
+function getThisEnd(val = 'month' as ManipulateTypeWithQuarter) {
+  return new Date(
+    dayjs()
+      .endOf(val as QUnitType)
+      .format('YYYY/MM/DD HH:mm:ss')
+  )
 }
 
 function getLastStart(val = 'month' as ManipulateType) {
@@ -14,6 +26,15 @@ function getLastStart(val = 'month' as ManipulateType) {
 
 function getLastEnd(val = 'month' as ManipulateType) {
   return new Date(dayjs().subtract(1, val).endOf(val).format('YYYY/MM/DD HH:mm:ss'))
+}
+
+function getYearToLastMonthEnd(): [Date, Date] {
+  const start = getThisStart('year')
+  const end = getLastEnd('month')
+  if (+start > +end) {
+    return [start, getThisEnd('day')]
+  }
+  return [start, end]
 }
 
 function getAround(val = 'month' as ManipulateType, type = 'add', num = 0) {
@@ -70,6 +91,8 @@ function getCustomRange(relativeToCurrentRange: string): [Date, Date] {
       ]
     case 'YearToThisMonth':
       return [new Date(dayjs().startOf('year').format('YYYY/MM/DD HH:mm:ss')), getThisEnd('month')]
+    case 'YearToLastMonthEnd':
+      return getYearToLastMonthEnd()
     case 'monthToYesterday':
       const sm = new Date(dayjs().startOf('month').format('YYYY/MM/DD HH:mm:ss'))
       const ld = getLastEnd('day')
@@ -99,6 +122,7 @@ export {
   getThisEnd,
   getLastStart,
   getLastEnd,
+  getYearToLastMonthEnd,
   getAround,
   getCustomRange,
   getAroundStart

--- a/core/core-frontend/src/locales/en.ts
+++ b/core/core-frontend/src/locales/en.ts
@@ -2886,6 +2886,7 @@ export default {
     last_3_days: 'Last 3 days',
     month_to_date: 'Month to date',
     year_to_date: 'Year to date',
+    year_to_last_month_end: 'Year to end of last month',
     exact_match: 'Exact',
     fuzzy_match: 'Fuzzy',
     option_type: 'Option type',

--- a/core/core-frontend/src/locales/tw.ts
+++ b/core/core-frontend/src/locales/tw.ts
@@ -2813,6 +2813,7 @@ export default {
     last_3_days: '最近3 天',
     month_to_date: '月初至今',
     year_to_date: '年初至今',
+    year_to_last_month_end: '年初至上月底',
     exact_match: '精確匹配',
     fuzzy_match: '模糊匹配',
     option_type: '選項類型',

--- a/core/core-frontend/src/locales/zh-CN.ts
+++ b/core/core-frontend/src/locales/zh-CN.ts
@@ -2819,6 +2819,7 @@ export default {
     last_3_days: '最近 3 天',
     month_to_date: '月初至今',
     year_to_date: '年初至今',
+    year_to_last_month_end: '年初至上月末',
     exact_match: '精确匹配',
     fuzzy_match: '模糊匹配',
     option_type: '选项类型',


### PR DESCRIPTION
### 变更内容
- 查询组件动态时间范围新增“年初至上月末”选项。
- 支持月范围、日期范围、日期时间范围的默认值和筛选配置。
- 新增统一的范围计算逻辑，并处理 1 月份时间倒挂边界。
- 补充中英文和繁中文案。
- 补充 Day.js quarter 插件初始化，保证已有“本季度”范围按季度计算。

### 关联 Issue
Closes #18398

### 验证
- npx eslint src/custom-component/v-query/time-format-dayjs.ts src/custom-component/v-query/FilterTime.vue src/custom-component/v-query/RangeFilterTime.vue src/custom-component/v-query/ConditionDefaultConfiguration.vue src/custom-component/v-query/QueryConditionConfiguration.vue src/locales/zh-CN.ts src/locales/tw.ts src/locales/en.ts --ext .vue,.ts
- npx tsc --noEmit --skipLibCheck --allowSyntheticDefaultImports --moduleResolution node --target es2020 --module esnext --lib es2020,dom src/custom-component/v-query/time-format-dayjs.ts
- 已验证“年初至上月末”正常月份和 1 月边界
- 已验证原有“年初至本月”和“本季度”范围计算
- git diff --check
