### PR TITLE
fix(图表): 修复表格隐藏字段后导出 Excel 列错位

### DIFF
--- a/core/core-backend/src/main/java/io/dataease/chart/server/ChartDataServer.java
+++ b/core/core-backend/src/main/java/io/dataease/chart/server/ChartDataServer.java
@@ -398,11 +398,9 @@ public class ChartDataServer implements ChartDataApi {
         Integer totalDepth = 0;
         List<CellRangeAddress> mergeConfig = new ArrayList<>();
         if (StringUtils.equalsAnyIgnoreCase(viewInfo.getType(), "table-normal", "table-info")) {
-            for (ChartViewFieldDTO tmpAxis : xAxis) {
-                if (tmpAxis.isHide()) {
-                    continue;
-                }
-                if (tmpAxis.getDeType().equals(DeTypeConstants.DE_INT) || tmpAxis.getDeType().equals(DeTypeConstants.DE_FLOAT)) {
+            List<ChartViewFieldDTO> visibleTableFields = xAxis.stream().filter(x -> !x.isHide()).toList();
+            for (ChartViewFieldDTO tmpAxis : visibleTableFields) {
+                if (isNumericType(tmpAxis.getDeType())) {
                     CellStyle formatterCellStyle = createCellStyle(wb, tmpAxis.getFormatterCfg(), null);
                     styles.add(formatterCellStyle);
                 } else {
@@ -429,8 +427,10 @@ public class ChartDataServer implements ChartDataApi {
                     }
                 }
             }
+            if (StringUtils.equalsAnyIgnoreCase(viewInfo.getType(), "table-info", "table-normal") && !"dataset".equalsIgnoreCase(viewInfo.getDownloadType())) {
+                xAxis = visibleTableFields;
+            }
             if ("table-info".equalsIgnoreCase(viewInfo.getType()) && !"dataset".equalsIgnoreCase(viewInfo.getDownloadType())) {
-                xAxis = xAxis.stream().filter(x -> !x.isHide()).toList();
                 Map<String, Object> tableCell = (Map<String, Object>) viewInfo.getCustomAttr().get("tableCell");
                 Boolean mergeCells = (Boolean) tableCell.get("mergeCells");
                 if (mergeCells != null && mergeCells) {
@@ -556,16 +556,25 @@ public class ChartDataServer implements ChartDataApi {
                             detailsSheet.setColumnWidth(j, 255 * 20);
                         } else if (cellValObj != null) {
                             try {
-                                if (StringUtils.equalsAnyIgnoreCase(viewInfo.getType(), "table-info", "table-normal") && Arrays.asList(DeTypeConstants.DE_INT,DeTypeConstants.DE_FLOAT).contains(xAxis.get(j).getDeType())) {
-                                    try {
-                                        FormatterCfgDTO formatterCfgDTO = xAxis.get(j).getFormatterCfg() == null ? new FormatterCfgDTO().setUnitLanguage(Lang.isChinese() ? "ch" : "en") : xAxis.get(j).getFormatterCfg();
-                                        row.getCell(j).setCellStyle(styles.get(j));
-                                        row.getCell(j).setCellValue(Double.valueOf(cellValue(formatterCfgDTO, new BigDecimal(cellValObj.toString()))));
-                                    } catch (Exception e) {
+                                boolean tableChart = StringUtils.equalsAnyIgnoreCase(viewInfo.getType(), "table-info", "table-normal");
+                                if (tableChart && j < xAxis.size()) {
+                                    ChartViewFieldDTO field = xAxis.get(j);
+                                    if (isNumericType(field.getDeType())) {
+                                        try {
+                                            BigDecimal numericValue = new BigDecimal(cellValObj.toString());
+                                            FormatterCfgDTO formatterCfgDTO = field.getFormatterCfg() == null ? new FormatterCfgDTO() : field.getFormatterCfg();
+                                            if (styles.size() > j && styles.get(j) != null) {
+                                                cell.setCellStyle(styles.get(j));
+                                            }
+                                            cell.setCellValue(Double.valueOf(cellValue(formatterCfgDTO, numericValue)));
+                                        } catch (Exception e) {
+                                            cell.setCellValue(cellValObj.toString());
+                                        }
+                                    } else {
                                         cell.setCellValue(cellValObj.toString());
                                     }
                                 } else {
-                                    if ((excelTypes[j].equals(DeTypeConstants.DE_INT) || excelTypes[j].equals(DeTypeConstants.DE_FLOAT)) && StringUtils.isNotEmpty(cellValObj.toString())) {
+                                    if (excelTypes != null && excelTypes.length > j && isNumericType(excelTypes[j]) && StringUtils.isNotEmpty(cellValObj.toString())) {
                                         cell.setCellValue(Double.valueOf(cellValObj.toString()));
                                     } else if (cellValObj != null) {
                                         cell.setCellValue(cellValObj.toString());
@@ -597,6 +606,10 @@ public class ChartDataServer implements ChartDataApi {
                 mergeConfig.forEach(detailsSheet::addMergedRegionUnsafe);
             }
         }
+    }
+
+    private static boolean isNumericType(Integer deType) {
+        return Objects.equals(deType, DeTypeConstants.DE_INT) || Objects.equals(deType, DeTypeConstants.DE_FLOAT);
     }
 
     private static List<CellRangeAddress> getMergeConfig(List<Object[]> data, int colIndex, int offsetHeight) {

--- a/core/core-backend/src/test/java/io/dataease/chart/server/ChartDataServerTest.java
+++ b/core/core-backend/src/test/java/io/dataease/chart/server/ChartDataServerTest.java
@@ -3,14 +3,22 @@ package io.dataease.chart.server;
 import io.dataease.api.chart.request.ChartExcelRequest;
 import io.dataease.chart.constant.ChartConstants;
 import io.dataease.chart.manage.ChartDataManage;
+import io.dataease.constant.DeTypeConstants;
 import io.dataease.exportCenter.manage.ExportCenterLimitManage;
 import io.dataease.exportCenter.util.ExportCenterUtils;
 import io.dataease.extensions.view.dto.ChartViewDTO;
+import io.dataease.extensions.view.dto.ChartViewFieldDTO;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -63,6 +71,81 @@ public class ChartDataServerTest {
         assertEquals(100_000, resultCount);
     }
 
+    @Test
+    public void setExcelDataKeepsTextColumnAfterHiddenNumericColumn() throws Exception {
+        ChartViewDTO view = tableView("table-info", Arrays.asList(
+                field("dim_a", "维度A", DeTypeConstants.DE_STRING, false),
+                field("metric_b", "指标B", DeTypeConstants.DE_FLOAT, true),
+                field("dim_c", "维度C", DeTypeConstants.DE_STRING, false)
+        ));
+
+        List<Object[]> details = new ArrayList<>();
+        details.add(new Object[]{"维度A", "维度C"});
+        details.add(new Object[]{"a1", "c1"});
+        Integer[] excelTypes = new Integer[]{
+                DeTypeConstants.DE_STRING,
+                DeTypeConstants.DE_FLOAT,
+                DeTypeConstants.DE_STRING
+        };
+
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("data");
+
+            ChartDataServer.setExcelData(
+                    sheet,
+                    wb.createCellStyle(),
+                    details.get(0),
+                    details,
+                    null,
+                    excelTypes,
+                    view,
+                    wb
+            );
+
+            Row dataRow = sheet.getRow(1);
+            assertEquals("c1", dataRow.getCell(1).getStringCellValue());
+        }
+    }
+
+    @Test
+    public void setExcelDataKeepsNumericTypeAfterHiddenTextColumnInNormalTable() throws Exception {
+        ChartViewDTO view = tableNormalView(
+                Arrays.asList(
+                        field("dim_a", "维度A", DeTypeConstants.DE_STRING, false),
+                        field("dim_b", "维度B", DeTypeConstants.DE_STRING, true)
+                ),
+                List.of(field("metric_c", "指标C", DeTypeConstants.DE_FLOAT, false))
+        );
+
+        List<Object[]> details = new ArrayList<>();
+        details.add(new Object[]{"维度A", "指标C"});
+        details.add(new Object[]{"a1", "12.5"});
+        Integer[] excelTypes = new Integer[]{
+                DeTypeConstants.DE_STRING,
+                DeTypeConstants.DE_STRING,
+                DeTypeConstants.DE_FLOAT
+        };
+
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet("data");
+
+            ChartDataServer.setExcelData(
+                    sheet,
+                    wb.createCellStyle(),
+                    details.get(0),
+                    details,
+                    null,
+                    excelTypes,
+                    view,
+                    wb
+            );
+
+            Row dataRow = sheet.getRow(1);
+            assertEquals(CellType.NUMERIC, dataRow.getCell(1).getCellType());
+            assertEquals(12.5, dataRow.getCell(1).getNumericCellValue(), 0.000001);
+        }
+    }
+
     private ChartDataServer chartDataServerWithExportLimits(Long viewLimit, Long datasetLimit) throws Exception {
         ChartDataManage chartDataManage = mock(ChartDataManage.class);
         when(chartDataManage.calcData(any(ChartViewDTO.class))).thenAnswer(invocation -> {
@@ -81,5 +164,45 @@ public class ChartDataServerTest {
         ChartDataServer chartDataServer = new ChartDataServer();
         ReflectionTestUtils.setField(chartDataServer, "chartDataManage", chartDataManage);
         return chartDataServer;
+    }
+
+    private ChartViewDTO tableView(String type, List<ChartViewFieldDTO> xAxis) {
+        ChartViewDTO view = new ChartViewDTO();
+        view.setType(type);
+        view.setXAxis(xAxis);
+        view.setYAxis(new ArrayList<>());
+        view.setXAxisExt(new ArrayList<>());
+        view.setYAxisExt(new ArrayList<>());
+        view.setExtStack(new ArrayList<>());
+        view.setDrillFields(new ArrayList<>());
+        view.setCustomAttr(tableCustomAttr());
+        return view;
+    }
+
+    private ChartViewDTO tableNormalView(List<ChartViewFieldDTO> xAxis, List<ChartViewFieldDTO> yAxis) {
+        ChartViewDTO view = tableView("table-normal", xAxis);
+        view.setYAxis(yAxis);
+        return view;
+    }
+
+    private Map<String, Object> tableCustomAttr() {
+        Map<String, Object> customAttr = new HashMap<>();
+        Map<String, Object> tableHeader = new HashMap<>();
+        tableHeader.put("headerGroup", false);
+        Map<String, Object> tableCell = new HashMap<>();
+        tableCell.put("mergeCells", false);
+        customAttr.put("tableHeader", tableHeader);
+        customAttr.put("tableCell", tableCell);
+        return customAttr;
+    }
+
+    private ChartViewFieldDTO field(String dataeaseName, String name, Integer deType, boolean hide) {
+        ChartViewFieldDTO field = new ChartViewFieldDTO();
+        field.setDataeaseName(dataeaseName);
+        field.setName(name);
+        field.setChartShowName(name);
+        field.setDeType(deType);
+        field.setHide(hide);
+        return field;
     }
 }


### PR DESCRIPTION
### 变更内容
- 修复表格导出 Excel 时，隐藏字段导致后续列类型错位的问题
- 隐藏指标字段后，后面的维度字段可以正常导出
- 补充隐藏指标、隐藏维度两类回归测试

### 问题原因
表格导出时会从数据行中移除隐藏字段，但写入 Excel 时仍可能使用原始字段顺序判断列类型，导致隐藏字段后的列使用了错误的类型信息。

### 验证
- 后端编译通过
- `ChartDataServerTest` 通过，5 个用例
- `git diff --check` 通过

Fixes #18367
