### PR TITLE
fix(图表): 修复最后一级仍显示下钻入口的问题

### DIFF
--- a/core/core-frontend/src/custom-component/indicator/DeIndicator.vue
+++ b/core/core-frontend/src/custom-component/indicator/DeIndicator.vue
@@ -15,6 +15,7 @@ import { valueFormatter } from '@/views/chart/components/js/formatter'
 import { storeToRefs } from 'pinia'
 import { isDashboard, trackBarStyleCheck } from '@/utils/canvasUtils'
 import ViewTrackBar from '@/components/visualization/ViewTrackBar.vue'
+import { hasNextDrillLevel } from '@/views/chart/components/views/util/drill'
 
 const props = defineProps({
   // 公共参数集
@@ -75,6 +76,7 @@ const viewTrack = ref(null)
 const indicatorRef = ref(null)
 const errMsg = ref('')
 const isError = ref(false)
+const drillFilters = ref([])
 const state = reactive({
   pointParam: null,
   data: null,
@@ -390,6 +392,7 @@ const calcData = (view, callback) => {
           errMsg.value = res.msg
         } else {
           chartData.value = res?.data as Partial<Chart['data']>
+          drillFilters.value = res?.drillFilters || []
           emit('onDrillFilters', res?.drillFilters)
 
           dvMainStore.setViewDataDetails(view.id, res)
@@ -398,9 +401,11 @@ const calcData = (view, callback) => {
         callback?.()
       })
       .catch(() => {
+        drillFilters.value = []
         callback?.()
       })
   } else {
+    drillFilters.value = []
     callback?.()
   }
 }
@@ -492,7 +497,8 @@ const trackMenu = computed(() => {
     (!mobileInPc.value || inMobile.value) &&
     trackMenuInfo.push('jump')
   linkageCount && view.value?.linkageActive && trackMenuInfo.push('linkage')
-  view.value.drillFields.length && trackMenuInfo.push('drill')
+  hasNextDrillLevel(view.value.drillFields, drillFilters.value.length) &&
+    trackMenuInfo.push('drill')
   // 如果同时配置jump linkage drill 切配置联动时同时下钻 在实际只显示两个 '跳转' '联动和下钻'
   if (trackMenuInfo.length === 3 && props.element.actionSelection.linkageActive === 'auto') {
     trackMenuInfo = ['jump', 'linkageAndDrill']

--- a/core/core-frontend/src/views/chart/components/views/components/ChartComponentG2Plot.vue
+++ b/core/core-frontend/src/views/chart/components/views/components/ChartComponentG2Plot.vue
@@ -30,6 +30,7 @@ import { L7ChartView } from '@/views/chart/components/js/panel/types/impl/l7'
 import { useI18n } from '@/hooks/web/useI18n'
 import { ExportImage } from '@antv/l7'
 import { configEmptyDataStyle } from '@/views/chart/components/js/panel/common/common_antv'
+import { hasNextDrillLevel } from '@/views/chart/components/views/util/drill'
 const { t } = useI18n()
 const dvMainStore = dvMainStoreWithOut()
 const { nowPanelTrackInfo, nowPanelJumpInfo, mobileInPc, embeddedCallBack, inMobile } =
@@ -669,7 +670,10 @@ const trackMenu = computed(() => {
       (!mobileInPc.value || inMobile.value) &&
       trackMenuInfo.push('jump')
     linkageCount && view.value?.linkageActive && trackMenuInfo.push('linkage')
-    view.value.drillFields.length && trackMenuInfo.push('drill')
+    hasNextDrillLevel(
+      curView?.drillFields || view.value.drillFields,
+      curView?.drillFilters?.length || 0
+    ) && trackMenuInfo.push('drill')
     // 如果同时配置jump linkage drill 切配置联动时同时下钻 在实际只显示两个 '跳转' '联动和下钻'
     if (trackMenuInfo.length === 3 && props.element.actionSelection.linkageActive === 'auto') {
       trackMenuInfo = ['jump', 'linkageAndDrill']

--- a/core/core-frontend/src/views/chart/components/views/components/ChartComponentS2.vue
+++ b/core/core-frontend/src/views/chart/components/views/components/ChartComponentS2.vue
@@ -31,6 +31,7 @@ import { isDashboard, trackBarStyleCheck } from '@/utils/canvasUtils'
 import { type SpreadSheet } from '@antv/s2'
 import { parseJson } from '../../js/util'
 import { useI18n } from '@/hooks/web/useI18n'
+import { hasNextDrillLevel, isCurrentDrillField } from '@/views/chart/components/views/util/drill'
 
 const dvMainStore = dvMainStoreWithOut()
 const {
@@ -570,7 +571,7 @@ const trackMenuCmp = computed(() => {
     (!mobileInPc.value || inMobile.value) &&
     trackMenuInfo.push('jump')
   linkageCount && view.value?.linkageActive && trackMenuInfo.push('linkage')
-  view.value.drillFields.length && trackMenuInfo.push('drill')
+  hasNextDrillLevel(view.value.drillFields, drillLength.value) && trackMenuInfo.push('drill')
   // 如果同时配置jump linkage drill 切配置联动时同时下钻 在实际只显示两个 '跳转' '联动和下钻'
   if (trackMenuInfo.length === 3 && props.element.actionSelection.linkageActive === 'auto') {
     trackMenuInfo = ['jump', 'linkageAndDrill']
@@ -605,7 +606,7 @@ const trackMenuCalc = itemId => {
     trackMenuInfo.push('jump')
   linkageCount && view.value?.linkageActive && trackMenuInfo.push('linkage')
   // 判断是否有下钻 同时判断下钻到第几层
-  if (view.value.drillFields.length && view.value.drillFields[drillLength.value].id === itemId) {
+  if (isCurrentDrillField(view.value.drillFields, drillLength.value, itemId)) {
     drillCount++
   }
   drillCount && trackMenuInfo.push('drill')

--- a/core/core-frontend/src/views/chart/components/views/util/drill.ts
+++ b/core/core-frontend/src/views/chart/components/views/util/drill.ts
@@ -1,0 +1,19 @@
+type DrillField = {
+  id?: string | number
+}
+
+export const hasNextDrillLevel = (drillFields?: unknown[], drillLevel = 0) => {
+  const fieldSize = Array.isArray(drillFields) ? drillFields.length : 0
+  return drillLevel >= 0 && fieldSize > 1 && drillLevel < fieldSize - 1
+}
+
+export const isCurrentDrillField = (
+  drillFields: DrillField[] | undefined,
+  drillLevel: number,
+  fieldId: string | number
+) => {
+  if (!hasNextDrillLevel(drillFields, drillLevel)) {
+    return false
+  }
+  return drillFields?.[drillLevel]?.id === fieldId
+}


### PR DESCRIPTION
### 变更内容
- 调整图表操作菜单的下钻判断逻辑，仅在存在下一层时显示下钻入口
- 处理 G2 图表、S2 表格、指标卡在最后一级下钻时的菜单展示
- 最后一级仍保留联动、跳转等可用操作

### 问题原因
原逻辑只判断图表是否配置了下钻字段，未结合当前下钻层级判断是否还能继续下钻。最后一级配置联动时，菜单仍可能展示“下钻”或“联动和下钻”。

### 验证
- 检查首层、中间层、最后一级的下钻菜单展示
- 检查最后一级同时配置联动、跳转时的菜单组合
- 执行相关前端文件 ESLint 检查
- 执行 `vite build --mode base`

Fixes #17935
