### PR TITLE
fix(图表): 修复条件样式提示文案异常

### DIFF
--- a/core/core-frontend/src/views/chart/components/editor/editor-senior/components/dialog/TableThresholdEdit.vue
+++ b/core/core-frontend/src/views/chart/components/editor/editor-senior/components/dialog/TableThresholdEdit.vue
@@ -445,7 +445,7 @@ init()
       <Icon name="icon_info_filled" class="icon-style"
         ><icon_info_filled class="svg-icon icon-style"
       /></Icon>
-      <span style="padding-left: 10px">{{ t('chart.table_threshold_tip') }}2</span>
+      <span style="padding-left: 10px">{{ t('chart.table_threshold_tip') }}</span>
     </div>
 
     <div @keydown.stop @keyup.stop style="max-height: 50vh; overflow-y: auto">


### PR DESCRIPTION
### 变更内容
- 修复条件样式设置弹窗中提示文案末尾多显示字符的问题。

### 验证
- 检查条件样式提示文案展示
- 执行相关文件 ESLint 检查
- 执行 `vite build --mode base`
