### PR TITLE
ci: pin Yikun/hub-mirror-action to a full commit SHA

### DIFF
--- a/.github/workflows/sync2gitee.yml
+++ b/.github/workflows/sync2gitee.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mirror the Github organization repos to Gitee.
-        uses: Yikun/hub-mirror-action@master
+        uses: Yikun/hub-mirror-action@ba51c01b28a6c9f95a25d4f1bcf6af2a147c0e18 # master
         with:
           src: 'github/dataease'
           dst: 'gitee/fit2cloud-feizhiyun'


### PR DESCRIPTION
### What
Pin `Yikun/hub-mirror-action@master` → `ba51c01…` in `sync2gitee.yml` (tag kept in a comment).

### Why
The step hands this third-party action a **Gitee SSH private key** (`secrets.GITEE_PRIVATE_KEY`) and a
**token** (`secrets.GITEE_TOKEN`). `@master` is a moving ref — if that action's default branch were
moved (compromise or accidental change), the new code would run with those credentials — the class of
issue behind the 2025 `tj-actions/changed-files` incident. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged (SHA = current tip of master). Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow, the credential exposure, and the pinned SHA myself.</sub>
