### PR TITLE
fix(图表): 修复数据集选择器部分数据集搜索不到

### DIFF
--- a/core/core-frontend/src/views/chart/components/editor/dataset-select/DatasetSelect.vue
+++ b/core/core-frontend/src/views/chart/components/editor/dataset-select/DatasetSelect.vue
@@ -3,7 +3,7 @@ import dvFolder from '@/assets/svg/dv-folder.svg'
 import icon_dataset from '@/assets/svg/icon_dataset.svg'
 import icon_done_outlined from '@/assets/svg/icon_done_outlined.svg'
 import { Tree } from '../../../../visualized/data/dataset/form/CreatDsGroup.vue'
-import { computed, ref, watch, onMounted, nextTick } from 'vue'
+import { computed, ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { Plus, Search } from '@element-plus/icons-vue'
 import { useI18n } from '@/hooks/web/useI18n'
 import { useAppStoreWithOut } from '@/store/modules/app'
@@ -105,10 +105,6 @@ const dsSelectProps = {
 const formRef = ref<FormInstance>()
 const searchStr = ref<string>()
 
-watch(searchStr, val => {
-  datasetSelector.value.filter(val)
-})
-
 const showTree = computed(() => {
   return (
     datasetTree.value && datasetTree.value.length > 0 && !loadingDatasetTree.value && orgCheck.value
@@ -131,6 +127,37 @@ const computedTree = computed(() => {
   }
   return datasetTree.value
 })
+
+// 预计算可见节点 ID 集合，避免树组件异步过滤时丢失匹配节点的父级路径
+const visibleNodeIds = new Set<string | number>()
+
+const buildVisibleIds = (nodes: Tree[], keyword: string): boolean => {
+  let anyMatch = false
+  for (const node of nodes) {
+    const selfMatch = !!node.name?.toLowerCase().includes(keyword)
+    const childMatch = node.children?.length ? buildVisibleIds(node.children, keyword) : false
+    if (selfMatch || childMatch) {
+      visibleNodeIds.add(node.id)
+      anyMatch = true
+    }
+  }
+  return anyMatch
+}
+
+let searchTimer: ReturnType<typeof setTimeout>
+watch(searchStr, val => {
+  clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => {
+    const keyword = val?.trim().toLowerCase()
+    visibleNodeIds.clear()
+    if (keyword) {
+      buildVisibleIds(computedTree.value || [], keyword)
+    }
+    datasetSelector.value.filter(val?.trim())
+  }, 300)
+})
+
+onBeforeUnmount(() => clearTimeout(searchTimer))
 
 const flattedTree = computed(() => {
   return _.filter(flatTree(computedTree.value), node => node.leaf)
@@ -186,8 +213,8 @@ const onDatasetChange = val => {
   emits('onDatasetChange', val)
 }
 const filterNode = (value: string, data: Tree) => {
-  if (!value) return true
-  return data.name?.includes(value)
+  if (!value?.trim()) return true
+  return visibleNodeIds.has(data.id)
 }
 
 const refresh = () => {


### PR DESCRIPTION
#### What this PR does / why we need it?

图表编辑器的数据集选择器直接依赖树组件完成节点过滤。当目录包含较多子节点时，树组件会分批异步遍历；命中节点的父级可能在子节点遍历完成前被判定为不可见，最终错误显示“暂无相关数据”。

#### Summary of your change

- 搜索前递归计算命中节点及其完整父级路径，通过节点 ID 集合完成过滤
- 为搜索输入增加 300 ms 防抖，减少连续输入触发的重复树遍历
- 组件卸载时清理搜索定时器
- 保持数据集与数据源选择模式共用同一过滤逻辑

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

#### Validation

- Production build passed with the Node.js version specified by the project (`vite build --mode distributed`)
- ESLint passed for `DatasetSelect.vue`
- Prettier check passed for `DatasetSelect.vue`
- Regression fixture verified that all matching leaves and their complete ancestor paths remain visible in a tree containing more than 80 sibling nodes
- Full `vue-tsc --noEmit` is currently blocked by the installed `@types/node` declarations using syntax unsupported by the project's TypeScript 4.9; all reported errors are under `node_modules/@types/node/ffi.d.ts`

#### Impact

The change only affects filtering in the chart editor's dataset selector. Data loading, permissions, and backend dataset queries are unchanged.
