### PR TITLE
fix(图表): 修复阈值告警 like/not_like 内存过滤参数颠倒导致不触发的问题

### DIFF
--- a/core/core-backend/src/main/java/io/dataease/chart/manage/ChartViewThresholdManage.java
+++ b/core/core-backend/src/main/java/io/dataease/chart/manage/ChartViewThresholdManage.java
@@ -621,9 +621,10 @@ public class ChartViewThresholdManage {
                 } else if (StringUtils.equals(term, "not_in")) {
                     return !Arrays.stream(item.getValue().split(",")).toList().contains(valueObj.toString());
                 } else if (StringUtils.equals(term, "like")) {
-                    return StringUtils.contains(item.getValue(), valueObj.toString());
+                    // 与 SQL 侧 field LIKE '%value%' 语义保持一致：行字段值包含配置的过滤值
+                    return StringUtils.contains(valueObj.toString(), item.getValue());
                 } else if (StringUtils.equals(term, "not_like")) {
-                    return !StringUtils.contains(item.getValue(), valueObj.toString());
+                    return !StringUtils.contains(valueObj.toString(), item.getValue());
                 } else if (StringUtils.equals(term, "null")) {
                     return false;
                 } else if (StringUtils.equals(term, "not_null")) {


### PR DESCRIPTION
#### What this PR does / why we need it?

阈值告警对字符串类型指标的 `like` / `not_like` 判断写反了参数：`StringUtils.contains(item.getValue(), valueObj.toString())` 判断的是"配置的过滤值包含行字段值"，与 SQL 生成侧 `field LIKE '%value%'`（见 `engine/trans/ExtWhere2Str.java` 的 `toLikeValue`，字段在前）语义相反。例如行值为 `DataEase v2`、配置值 `Ease` 时 SQL 会命中，但内存告警判断不命中——告警该触发时不触发（not_like 反向同样错误）。

#### Summary of your change

交换 `StringUtils.contains` 的两个参数，使行字段值作为被搜索方，与 SQL 侧语义一致。
位置：`core/core-backend/.../chart/manage/ChartViewThresholdManage.java`

#### Checklist

- [x] 本地编译通过（core-backend，JDK21）
- [x] Commit message 遵循 Conventional Commits
- [x] 无文档影响