### PR TITLE
fix(分享): 修复 Ticket 开关接口在分享记录不存在时 NPE 的问题

### DIFF
--- a/core/core-backend/src/main/java/io/dataease/share/manage/ShareTicketManage.java
+++ b/core/core-backend/src/main/java/io/dataease/share/manage/ShareTicketManage.java
@@ -121,6 +121,10 @@ public class ShareTicketManage {
         queryWrapper.eq("resource_id", resourceId);
         queryWrapper.eq("creator", AuthUtils.getUser().getUserId());
         XpackShare xpackShare = xpackShareMapper.selectOne(queryWrapper);
+        // 分享记录可能不存在（尚未创建分享或 resourceId 无效），避免直接 NPE
+        if (ObjectUtils.isEmpty(xpackShare)) {
+            DEException.throwException("分享记录不存在");
+        }
         xpackShare.setTicketRequire(require);
         xpackShareMapper.updateById(xpackShare);
     }


### PR DESCRIPTION
#### What this PR does / why we need it?

`ShareTicketManage#switchRequire`（`/ticket/switchRequire` 接口）在当前用户对 resourceId 尚无分享记录时，`selectOne` 返回 null 直接调用 `setTicketRequire` 抛 NPE。同类方法 `deleteTicket` 均有判空，此处属于遗漏。

#### Summary of your change

仿照同类方法补判空，抛出业务异常"分享记录不存在"。

#### Checklist

- [x] 本地编译通过（core-backend，JDK21）
- [x] Commit message 遵循 Conventional Commits
- [x] 无文档影响