### PR TITLE
fix(图表): 修复自定义底图缩放按钮与版权信息重叠

### DIFF
--- a/core/core-frontend/src/views/chart/components/js/panel/common/common_antv.ts
+++ b/core/core-frontend/src/views/chart/components/js/panel/common/common_antv.ts
@@ -1744,6 +1744,31 @@ export class CustomZoom extends Zoom {
 }
 
 class CustomTileZoom extends CustomZoom {
+  private attributionObserver?: ResizeObserver
+
+  onAdd() {
+    const container = super.onAdd()
+    const attributionCorner = this.mapsService
+      .getContainer()
+      ?.querySelector<HTMLElement>('.maplibregl-ctrl-bottom-right')
+    if (attributionCorner) {
+      // MapLibre 版权栏与 L7 控件独立布局，按实际高度避让，兼容换行和画布缩放。
+      const updateOffset = () => {
+        container.style.marginBottom = `${attributionCorner.offsetHeight + 8}px`
+      }
+      updateOffset()
+      this.attributionObserver = new ResizeObserver(updateOffset)
+      this.attributionObserver.observe(attributionCorner)
+    }
+    return container
+  }
+
+  onRemove() {
+    this.attributionObserver?.disconnect()
+    this.attributionObserver = undefined
+    super.onRemove()
+  }
+
   resetButtonGroup(container) {
     DOM.clearChildren(container)
     const zoomIn = () => this.mapsService.zoomIn({ duration: 0 })


### PR DESCRIPTION
#### What this PR does / why we need it?
自定义底图的缩放按钮与版权栏分别由 L7、MapLibre 定位，均占用右下角，导致重叠。

#### Summary of your change
仅修改 common_antv.ts：按版权栏实际高度动态调整缩放按钮底部间距，保留 8px 空隙，兼容文字换行与画布缩放；移除控件时清理 ResizeObserver。

验证：ESLint、Prettier、git diff --check 通过；实际 MapLibre/L7 控件的单行、多行、画布缩放、空版权栏和监听清理验证通过。

#### Please indicate you've done the following:
- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of Conventional Commits specification.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed. No docs changes needed.