### PR TITLE
fix(图表): 打开数据集选择框时自动聚焦搜索框

### DIFF
--- a/core/core-frontend/src/views/chart/components/editor/dataset-select/DatasetSelect.vue
+++ b/core/core-frontend/src/views/chart/components/editor/dataset-select/DatasetSelect.vue
@@ -10,6 +10,7 @@ import { useAppStoreWithOut } from '@/store/modules/app'
 import { cloneDeep, filter, find, forEach, union } from 'lodash-es'
 import { getDatasetTree, getDatasourceList } from '@/api/dataset'
 import { ElFormItem, FormInstance } from 'element-plus-secondary'
+import type { InputInstance } from 'element-plus-secondary'
 import { useEmitt } from '@/hooks/web/useEmitt'
 import { useCache } from '@/hooks/web/useCache'
 import { useUserStoreWithOut } from '@/store/modules/user'
@@ -41,6 +42,7 @@ const props = withDefaults(
 )
 
 const datasetSelector = ref(null)
+const searchInput = ref<InputInstance>()
 
 const loadingDatasetTree = ref(false)
 
@@ -288,6 +290,9 @@ const dsClick = (data: Tree) => {
 const _popoverShow = ref(false)
 async function onPopoverShow() {
   _popoverShow.value = true
+  await nextTick()
+  if (!_popoverShow.value) return
+  searchInput.value?.focus()
   await scrollCurrentNodeIntoView()
 }
 function onPopoverHide() {
@@ -401,6 +406,7 @@ onMounted(() => {
               </el-button>
             </div>
             <el-input
+              ref="searchInput"
               :effect="themes"
               v-model="searchStr"
               :placeholder="t('dataset.search')"


### PR DESCRIPTION
#### What this PR does / why we need it?
仪表板和大屏打开数据集选择框后，焦点仍停留在触发输入框，需要再点击搜索框才能输入。

#### Summary of your change
仅修改 DatasetSelect.vue：在弹出框显示并完成 DOM 更新后，自动聚焦搜索输入框；保留已选节点的展开与滚动逻辑。关闭后再次打开也会自动聚焦。

验证：ESLint、Prettier 和 git diff --check 通过，尚未实测页面交互。

#### Please indicate you've done the following:
- [x] Made sure tests are passing and test coverage is added if needed. 本次为低影响焦点调整，已完成静态检查，未新增自动化测试。
- [x] Made sure commit message follow the rule of Conventional Commits specification.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed. 无需修改文档。
